### PR TITLE
[fix] README の GitHub 参照を修正 (sk2sat → sksat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Trochia
 
-[![Build Status on GitHub Actions](https://github.com/sk2sat/rocket_simulator/workflows/build/badge.svg)](https://github.com/sk2sat/rocket_simulator/actions)
-[![release](https://img.shields.io/github/v/release/sk2sat/trochia?style=flat-square)](https://github.com/sk2sat/trochia/releases)
-[![issues](https://img.shields.io/github/issues/sk2sat/trochia?color=red&style=flat-square)](https://github.com/sk2sat/trochia/issues)
-[![license](https://img.shields.io/github/license/sk2sat/trochia?style=flat-square)](./LICENSE)
+[![Build Status on GitHub Actions](https://github.com/sksat/trochia/workflows/build/badge.svg)](https://github.com/sksat/trochia/actions)
+[![release](https://img.shields.io/github/v/release/sksat/trochia?style=flat-square)](https://github.com/sksat/trochia/releases)
+[![issues](https://img.shields.io/github/issues/sksat/trochia?color=red&style=flat-square)](https://github.com/sksat/trochia/issues)
+[![license](https://img.shields.io/github/license/sksat/trochia?style=flat-square)](./LICENSE)
 
 ## trochia: trajectory of rocket and ground-hit-point calculator
 
@@ -14,16 +14,16 @@ Trochia is a rocket flight simulator written by modern C++.
 
 There are pre-built binaries of latest release for some platform.
 
-- [Linux](https://github.com/sk2sat/trochia/releases/latest/download/trochia-linux.zip)
-- [Mac OS](https://github.com/sk2sat/trochia/releases/latest/download/trochia-mac.zip)
-- [Windows](https://github.com/sk2sat/trochia/releases/latest/download/trochia-windows.zip)
+- [Linux](https://github.com/sksat/trochia/releases/latest/download/trochia-linux.zip)
+- [Mac OS](https://github.com/sksat/trochia/releases/latest/download/trochia-mac.zip)
+- [Windows](https://github.com/sksat/trochia/releases/latest/download/trochia-windows.zip)
 
-Please see [Release Page](https://github.com/sk2sat/trochia/releases) for details.
+Please see [Release Page](https://github.com/sksat/trochia/releases) for details.
 
 ### Build from Source
 
 ```sh
-$ git clone https://github.com/sk2sat/trochia && cd trochia
+$ git clone https://github.com/sksat/trochia && cd trochia
 $ mkdir build && cd build
 $ cmake ..
 $ make
@@ -41,7 +41,7 @@ $ trochia
 
 ## Author
 
-GitHub: [sk2sat](https://github.com/sk2sat)
+GitHub: [sksat](https://github.com/sksat)
 
 Twitter: [@sksat\_tty](https://twitter.com/sksat_tty)
 


### PR DESCRIPTION
## 変更内容

README.md の GitHub アカウント / リポジトリ参照を修正します。

- `sk2sat` → `sksat`（アカウント名が変わったため）
- ビルドステータスのバッジが旧リポジトリ名 `rocket_simulator` を指していたので `trochia` に修正

## 理由

各バッジ（build / release / issues / license）とインストール・cloneリンクが `sk2sat/...`（ビルドバッジは `sk2sat/rocket_simulator`）を指しており、解決できなくなっていました。`sksat/trochia` に向けます。

Twitter ハンドル `@sksat_tty` は既に正しいため変更していません。

## 補足

ドキュメントのみの変更です（コードは触っていません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46