### PR TITLE
[ci] modernize CI workflow (latest actions, master-only triggers, CMake >= 3.5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,9 @@ on:
   push:
     branches:
       - master
-      - develop
-      - feature/*
   pull_request:
     branches:
       - master
-      - develop
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v7
     - name: install C++17 compiler
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -78,7 +78,7 @@ jobs:
           7z a trochia-Windows.zip trochia
 
     - name: Upload archive as artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v7
       with:
         name: "trochia-${{ runner.os }}"
         path: "trochia-${{ runner.os }}.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - master
       - develop
       - feature/*
+  pull_request:
+    branches:
+      - master
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v7
 
     - name: install C++17 compiler for Ubuntu
       if: matrix.os == 'ubuntu-latest'
@@ -78,7 +78,7 @@ jobs:
           7z a trochia-Windows.zip trochia
 
     - name: Upload archive as artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v7
       with:
         name: "trochia-${{ runner.os }}"
         path: "trochia-${{ runner.os }}.zip"
@@ -89,9 +89,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v8
       with:
         name: trochia-Linux
+        path: trochia-Linux
     - name: move archive
       run: mv trochia-Linux/trochia-Linux.zip trochia-linux.zip
     - uses: JasonEtco/upload-to-release@master
@@ -100,9 +101,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v8
       with:
         name: trochia-macOS
+        path: trochia-macOS
     - name: move archive
       run: mv trochia-macOS/trochia-macOS.zip trochia-mac.zip
     - uses: JasonEtco/upload-to-release@master
@@ -111,9 +113,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v8
       with:
         name: trochia-Windows
+        path: trochia-Windows
     - name: move archive
       run: mv trochia-Windows/trochia-Windows.zip trochia-windows.zip
     - uses: JasonEtco/upload-to-release@master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 # cmake common config
-cmake_minimum_required(VERSION 3.1)
+# CMake 4.x removed compatibility with minimums below 3.5, so requesting 3.1
+# makes configure fail on modern CMake (e.g. the GitHub Actions runners).
+cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
 


### PR DESCRIPTION
## 概要

`master` 一本運用に向けて CI を整理し、build ワークフローが通るようにします。CI が落ちていた原因は2つで、どちらもコードではなく CI/ビルド設定の問題です。

## 変更点

1. **非推奨 action の更新**（GitHub が自動失敗させる `@v1` を排除）
   - `actions/checkout` v1 → **v7**
   - `actions/upload-artifact` v1 → **v7**（OS 毎にユニーク名なので v4+ の同名禁止に抵触せず）
   - `actions/download-artifact` v1 → **v8**（v4+ は名前のサブディレクトリに展開しないため、各 download に `path:` を追加して後続の `mv` を維持）
2. **トリガーを master 一本に**（develop は廃止するため、build.yml は push / pull_request とも master のみ）
3. **CMake 最低バージョン 3.1 → 3.5**
   - CMake 4.x（GitHub ランナー）は `< 3.5` 互換を削除しており、`configure` が失敗していた（macOS ランナーで確認: *Compatibility with CMake < 3.5 has been removed*）

## 検証フロー

本PRは `develop` 宛なので CI は走りません（master 一本トリガーのため意図通り）。本PRを `develop` にマージ後、**#43（develop→master）が master 宛 PR として CI を実行**するので、そこで green を確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46