### PR TITLE
[ci] update Eigen/toml11 so the build passes under CMake 4.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ include(ExternalProject)
 set(EIGEN_BUILD_DIR ${DEPS_BUILD_DIR}/eigen)
 ExternalProject_Add(
 	eigen
-	URL				https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
+	URL				https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
 	PREFIX			${EIGEN_BUILD_DIR}
 	CMAKE_ARGS		-DCMAKE_INSTALL_PREFIX=${DEPS_ROOT}
 	BUILD_COMMAND	""
@@ -70,9 +70,9 @@ set(TOML11_BUILD_DIR ${DEPS_BUILD_DIR}/toml11)
 ExternalProject_Add(
 	toml11
 	GIT_REPOSITORY	https://github.com/ToruNiina/toml11
-	GIT_TAG			v3.2.0
+	GIT_TAG			v3.8.1
 	PREFIX			${TOML11_BUILD_DIR}
-	CMAKE_ARGS		-DCMAKE_INSTALL_PREFIX=${DEPS_ROOT} -Dtoml11_BUILD_TEST=OFF
+	CMAKE_ARGS		-DCMAKE_INSTALL_PREFIX=${DEPS_ROOT} -Dtoml11_BUILD_TEST=OFF -DCMAKE_CXX_STANDARD=17
 )
 
 add_dependencies(${TROCHIA} eigen toml11)


### PR DESCRIPTION
## 概要

現行ランナー（CMake 4.x）で build CI を通します。原因は、ExternalProject で固定取得している依存の `cmake_minimum_required` が古く（Eigen 3.3.7 → 2.8.5、toml11 v3.2.0 → 2.8）、**CMake 4.0 が「3.5 未満との互換」を削除**したため、依存の configure が失敗していたことでした。

依存を `cmake_minimum_required >= 3.5` のバージョンへ更新し、回避策（`CMAKE_POLICY_VERSION_MINIMUM`）を不要にします。

## 変更点

- **Eigen** `3.3.7` → `3.4.0`（`cmake_minimum_required(VERSION 3.5.0)`）
- **toml11** `v3.2.0` → `v3.8.1`（`cmake_minimum_required(VERSION 3.5)`）
  - v3.8.1 は configure 時に `CMAKE_CXX_STANDARD` が未定義だと FATAL_ERROR になるため `-DCMAKE_CXX_STANDARD=17` を付与（v3 API は据え置きでソース変更不要）
- `strategy.fail-fast: false`（Windows ジョブが落ちても Linux/macOS を巻き込まない）

## Windows について

Windows(MSVC) は別要因（`src/simulation.cpp` の C++20 指定イニシャライザ）でコンパイルに失敗するため、本PRの対象外です（別途対応）。`fail-fast: false` により Linux/macOS は緑のままです。

CI: macOS / ubuntu = pass、windows = fail（既知・許容）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46