### PR TITLE
[ci] add googletest unit-test infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: install dependencies
+      run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libeigen3-dev libgtest-dev
+
+    - name: configure
+      run: cmake -B build -DTROCHIA_BUILD_TESTS=ON
+
+    # build only the tests (not the main target, to skip the ExternalProject deps)
+    - name: build tests
+      run: cmake --build build --target tests --parallel
+
+    - name: run tests
+      run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,3 +76,10 @@ ExternalProject_Add(
 )
 
 add_dependencies(${TROCHIA} eigen toml11)
+
+# unit tests (off by default; uses system Eigen + googletest)
+option(TROCHIA_BUILD_TESTS "Build unit tests" OFF)
+if(TROCHIA_BUILD_TESTS)
+	enable_testing()
+	add_subdirectory(test)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Unit tests (googletest).
+#
+# These use the system Eigen and googletest so they build quickly without the
+# ExternalProject dependencies of the main target. Enable with:
+#   cmake -DTROCHIA_BUILD_TESTS=ON ..
+#   cmake --build . --target tests   # builds only the tests (no ExternalProject)
+#   ctest
+
+find_package(GTest REQUIRED)
+include(GoogleTest)
+
+# Eigen is header-only; just locate its include directory (don't rely on an
+# imported target, which some Eigen CMake packages don't provide).
+find_path(EIGEN3_INCLUDE_DIR Eigen/Geometry
+	PATHS /usr/include/eigen3 /usr/local/include/eigen3 /opt/homebrew/include/eigen3)
+if(NOT EIGEN3_INCLUDE_DIR)
+	message(FATAL_ERROR "Eigen headers (Eigen/Geometry) not found")
+endif()
+
+file(GLOB TEST_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp")
+
+# aggregate target so CI can build just the tests without the main executable
+add_custom_target(tests)
+
+foreach(test_src ${TEST_SOURCES})
+	get_filename_component(test_name ${test_src} NAME_WE)
+	add_executable(${test_name} ${test_src})
+	target_compile_features(${test_name} PRIVATE cxx_std_20)
+	target_include_directories(${test_name} PRIVATE
+		"${CMAKE_SOURCE_DIR}/src" "${EIGEN3_INCLUDE_DIR}")
+	target_link_libraries(${test_name} PRIVATE GTest::gtest GTest::gtest_main)
+	gtest_discover_tests(${test_name})
+	add_dependencies(tests ${test_name})
+endforeach()

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Lightweight test runner: compiles each test/test_*.cpp against the header-only
+# parts of src/ using the system Eigen and links googletest. It deliberately
+# avoids the heavy ExternalProject deps of the main build.
+#
+# For the CMake/ctest path instead, see test/CMakeLists.txt.
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+SRC=src
+EIGEN=${EIGEN_INCLUDE:-/usr/include/eigen3}
+CXX=${CXX:-g++}
+FLAGS=(-std=c++20 -I "$SRC" -I "$EIGEN" -Wall -Wextra -g)
+GTEST=(-lgtest -lgtest_main -lpthread)
+
+out=$(mktemp -d)
+trap 'rm -rf "$out"' EXIT
+
+fail=0
+for t in test/test_*.cpp; do
+	name=$(basename "$t" .cpp)
+	echo "=== building $name ==="
+	if ! "$CXX" "${FLAGS[@]}" "$t" -o "$out/$name" "${GTEST[@]}"; then
+		echo "BUILD FAILED: $name"
+		fail=1
+		continue
+	fi
+	echo "=== running $name ==="
+	if ! "$out/$name"; then
+		fail=1
+	fi
+done
+
+if [ "$fail" -ne 0 ]; then
+	echo "SOME TESTS FAILED"
+else
+	echo "ALL TESTS PASSED"
+fi
+exit "$fail"

--- a/test/test_math.cpp
+++ b/test/test_math.cpp
@@ -1,0 +1,25 @@
+// sanity tests for the math helpers (validates the test harness itself)
+#include <gtest/gtest.h>
+#include <cmath>
+#include "math.hpp"
+
+namespace m = trochia::math;
+
+TEST(Math, Deg2Rad) { EXPECT_NEAR(m::deg2rad(180.0), m::pi, 1e-12); }
+TEST(Math, Rad2Deg) { EXPECT_NEAR(m::rad2deg(m::pi), 180.0, 1e-12); }
+TEST(Math, Lerp)    { EXPECT_NEAR(m::lerp(0.0, 10.0, 0.25), 2.5, 1e-12); }
+
+TEST(Math, Sqrt) {
+	EXPECT_NEAR(m::sqrt(2.0), std::sqrt(2.0), 1e-9);
+	EXPECT_NEAR(m::sqrt(0.0), 0.0, 1e-12);
+}
+
+TEST(Math, Sin) { EXPECT_NEAR(m::sin(0.5), std::sin(0.5), 1e-9); }
+
+TEST(Math, QuatVecRoundtrip) {
+	m::Vector4 v;
+	v << 1, 2, 3, 4;
+	const auto q  = m::vec2quat(v);
+	const auto v2 = m::quat2vec(q);
+	EXPECT_TRUE(v.isApprox(v2));
+}


### PR DESCRIPTION
## 概要

ユニットテストの基盤を整備します（#40）。今後のバグ修正を **TDD** で進めるための土台です。

## 内容

- **gtest ユニットテスト**: `test/`（動作確認用の `test_math.cpp` 1本）、`test/CMakeLists.txt`（システム Eigen + googletest、`tests` 集約ターゲット）
- `CMakeLists.txt` に `option(TROCHIA_BUILD_TESTS OFF)` + `add_subdirectory(test)`
- `test/run_tests.sh`: ExternalProject 不要の高速ローカル実行
- **CI** `.github/workflows/test.yml`（ubuntu）: `tests` ターゲットのみビルドして `ctest` 実行 → eigen/toml11 のダウンロードを回避

## 補足

テスト本体（dynamics 等）は後続のバグ修正 PR で TDD として追加します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46