### PR TITLE
[ci] add AddressSanitizer/UBSan support

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -1,0 +1,34 @@
+name: Sanitize
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  sanitize:
+    runs-on: ubuntu-latest
+    env:
+      # make UBSan failures abort (and show a stack); ASan aborts by default
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+      ASAN_OPTIONS: detect_leaks=0
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: install dependencies
+      run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libeigen3-dev libgtest-dev
+
+    - name: configure (ASan + UBSan)
+      run: cmake -B build -DTROCHIA_BUILD_TESTS=ON -DTROCHIA_SANITIZE=ON
+
+    # build only the tests (not the main target, to skip the ExternalProject deps)
+    - name: build tests
+      run: cmake --build build --target tests --parallel
+
+    - name: run tests under sanitizers
+      run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,14 @@ elseif(MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
 endif()
 
+# AddressSanitizer + UndefinedBehaviorSanitizer (applies to all targets,
+# including the tests). Enable with: cmake -DTROCHIA_SANITIZE=ON ..
+option(TROCHIA_SANITIZE "Build with AddressSanitizer + UndefinedBehaviorSanitizer" OFF)
+if(TROCHIA_SANITIZE)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,undefined -fno-omit-frame-pointer -g")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address,undefined")
+endif()
+
 # dependency
 set(DEPS_ROOT        ${PROJECT_BINARY_DIR}/deps)
 set(DEPS_BUILD_DIR   ${DEPS_ROOT}/build)


### PR DESCRIPTION
## 概要

ASan / UBSan の基盤を追加します。#37 のような未定義動作（use-after-scope 等）を**検出・修正検証**するための土台です。

## 内容

- **CMake**: `option(TROCHIA_SANITIZE OFF)` → `-fsanitize=address,undefined -fno-omit-frame-pointer -g` を全ターゲット（テスト含む）に付与
- **CI** `.github/workflows/sanitize.yml`（ubuntu）: `-DTROCHIA_BUILD_TESTS=ON -DTROCHIA_SANITIZE=ON` で `tests` をビルドし、**ASan/UBSan 下で `ctest`** 実行

## 補足

現状のテストは sanity のみなので緑です。後続のバグ修正 PR で `do_step` 等を叩くテストを足すと、この CI が UB を自動検出します（ローカルで ASan が heap-overflow を実際に検知することも確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46