### PR TITLE
[fix] avoid Eigen use-after-scope in do_step (issue #37)

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -160,9 +160,12 @@ auto trochia::simulation::do_step(Simulation &sim, solver::solver<rocket::Rocket
 			0.0);
 
 	// airspeed vector(NED, body)
-	const auto va_ned	= vel_ned.vec - wind_ned;
-	const auto va_body	= coordinate::dcm::ned2body(rocket.quat) * va_ned;
-	const auto va		= va_body.norm();
+	// NOTE: assign to concrete types. Binding an Eigen product to `auto` keeps a
+	// lazy expression template that references the temporary matrix returned by
+	// ned2body(); reading it afterwards is a use-after-scope (issue #37).
+	const math::Vector3 va_ned	= vel_ned.vec - wind_ned;
+	const math::Vector3 va_body	= coordinate::dcm::ned2body(rocket.quat) * va_ned;
+	const math::Float   va		= va_body.norm();
 	if(va > rocket.va_max)
 		rocket.va_max	= va;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,12 @@ add_custom_target(tests)
 
 foreach(test_src ${TEST_SOURCES})
 	get_filename_component(test_name ${test_src} NAME_WE)
-	add_executable(${test_name} ${test_src})
+	# tests named test_sim_* exercise the simulation, so link its source
+	set(srcs ${test_src})
+	if(test_name MATCHES "^test_sim")
+		list(APPEND srcs "${CMAKE_SOURCE_DIR}/src/simulation.cpp")
+	endif()
+	add_executable(${test_name} ${srcs})
 	target_compile_features(${test_name} PRIVATE cxx_std_20)
 	target_include_directories(${test_name} PRIVATE
 		"${CMAKE_SOURCE_DIR}/src" "${EIGEN3_INCLUDE_DIR}")

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -20,8 +20,13 @@ trap 'rm -rf "$out"' EXIT
 fail=0
 for t in test/test_*.cpp; do
 	name=$(basename "$t" .cpp)
+	# tests named test_sim_* exercise the simulation, so compile its source too
+	extra=()
+	if [[ "$name" == test_sim_* ]]; then
+		extra+=(src/simulation.cpp)
+	fi
 	echo "=== building $name ==="
-	if ! "$CXX" "${FLAGS[@]}" "$t" -o "$out/$name" "${GTEST[@]}"; then
+	if ! "$CXX" "${FLAGS[@]}" "$t" "${extra[@]}" -o "$out/$name" "${GTEST[@]}"; then
 		echo "BUILD FAILED: $name"
 		fail=1
 		continue

--- a/test/test_sim_dynamics.cpp
+++ b/test/test_sim_dynamics.cpp
@@ -1,0 +1,66 @@
+// Exercises simulation::do_step so the sanitizers cover the flight dynamics.
+//
+// Regression test for issue #37: do_step held the airspeed as an Eigen
+// expression template (`auto va_body = ned2body(quat) * va_ned`) that referenced
+// the temporary matrix returned by ned2body(); reading it afterwards is a
+// stack-use-after-scope (caught here under -fsanitize=address). The trajectory
+// must also stay finite.
+#include <gtest/gtest.h>
+#include <cmath>
+#include <fstream>
+#include <string>
+#include "simulation.hpp"
+#include "solver.hpp"
+
+using namespace trochia;
+
+namespace {
+	std::string write_eng() {
+		const std::string path = "/tmp/trochia_test_sim.eng";
+		std::ofstream o(path);
+		o << "TestMotor 112 1150 P 1.0 2.0 Test\n"
+		  << "0.0 0.0\n"
+		  << "0.1 500.0\n"
+		  << "1.0 500.0\n"
+		  << "2.0 0.0\n";
+		return path;
+	}
+
+	simulation::Simulation make_sim() {
+		simulation::Simulation sim;
+		sim.dt        = 0.01;
+		sim.wind_speed = 3.0;
+		sim.wind_dir   = -90.0;
+		sim.launcher   = environment::Launcher(5.0, 90.0, 85.0);
+
+		auto &r = sim.rocket;
+		r.diameter = 0.112; r.length = 1.15; r.mass = 5.0;
+		r.lcg0 = 0.90; r.lcgf = 0.90; r.lcgp = 1.00; r.lcp = 1.10;
+		r.I0 = 1.2; r.If = 1.2; r.Cd = 0.44; r.Cna = 7.84;
+		r.engine.load_eng(write_eng());
+		r.Cmq = -1.0 * r.Cna / 2.0 * std::pow((r.lcp - r.lcg0) / r.length, 2.0);
+
+		r.time = 0.0;
+		r.pos.vec.setZero();
+		r.vel.vec.setZero();
+		r.acc.vec.setZero();
+		r.omega.setZero();
+		r.domega.setZero();
+		r.quat = sim.launcher.get_angle();
+		return sim;
+	}
+}
+
+TEST(SimDynamics, DoStepStaysFinite) {
+	auto sim = make_sim();
+	auto solve = solver::RK4(sim.rocket, rocket::Rocket::dx);
+
+	// a non-trivial upward velocity so the airspeed vector is exercised
+	sim.rocket.vel.vec = math::Vector3(0.0, 0.0, -30.0); // NED: down is +, so up
+
+	for (int i = 0; i < 50; ++i) {
+		trochia::simulation::do_step(sim, solve);
+		ASSERT_TRUE(std::isfinite(sim.rocket.pos.altitude())) << "altitude NaN at step " << i;
+		ASSERT_TRUE(std::isfinite(sim.rocket.vel.vec.norm())) << "velocity NaN at step " << i;
+	}
+}


### PR DESCRIPTION
## 概要

issue #37（Windows と Arch Linux、また gcc と clang で計算結果が大きく異なる）の**支配的原因の一つ**である未定義動作を修正します。

## 根本原因: Eigen の式テンプレート + `auto` + 一時オブジェクトの寿命

`do_step` の対気速度計算は次のようになっていました:
```cpp
const auto va_ned  = vel_ned.vec - wind_ned;
const auto va_body = coordinate::dcm::ned2body(rocket.quat) * va_ned;  // (A)
const auto va      = va_body.norm();                                    // (B)
```

Eigen は遅延評価で、`行列 * ベクトル` は**その場では計算されず**、オペランドへの参照を保持した式テンプレート（`Eigen::Product<...>`）を返します。`auto` で受けると `va_body` はこの式テンプレートそのものになります。

ここで `ned2body(rocket.quat)` は **`Matrix3` を値返し**する＝**一時オブジェクト**です。式テンプレート `va_body` はその一時行列への参照を握りますが、一時行列の寿命は (A) の文末（`;`）まで。したがって (B) で `va_body` を評価した時点では、**既に破棄されたスタック上の行列を読む**ことになります（stack-use-after-scope）。`va_body.z()` / `.x()`（迎角）でも同様です。

これは Eigen 公式も警告している `auto` の典型的な落とし穴です（式テンプレートを `auto` で受けてはいけない）。

## なぜプラットフォーム依存になるのか（#37 との関係）

use-after-scope は「解放済みスタック領域を読む」UB です。そこに何が残っているかはスタックの再利用や最適化（インライン展開・レジスタ割り当て・SIMD 化）に依存するため、**コンパイラ・最適化レベルごとに読む値が変わります**。対気速度 → 迎角・法線力 → 姿勢 … と伝播するので、わずかな差が軌道全体に増幅され、#37 の「環境で結果が変わる」症状になります。

gcc/clang は（C++17 既定では）クラッシュせず黙って古い値を読むため**従来は表面化せず**、Windows ジョブは別要因で CI のビルド段階に到達していなかったため気づかれていませんでした。

## AddressSanitizer による検出（証拠）

```
==ERROR: AddressSanitizer: stack-use-after-scope on address 0x...
    in trochia::simulation::do_step(...) src/simulation.cpp:165
SUMMARY: AddressSanitizer: stack-use-after-scope ... in _mm_loadu_pd
```

## 修正

対気速度ベクトルを**具象型**（`math::Vector3` / `math::Float`）に代入し、一時行列が生存している (A) の評価時点で**即時に計算**させます。

```cpp
const math::Vector3 va_ned  = vel_ned.vec - wind_ned;
const math::Vector3 va_body = coordinate::dcm::ned2body(rocket.quat) * va_ned;
const math::Float   va      = va_body.norm();
```

※ `save_data` の `ned2body * vec` は**名前付きローカル**（関数末まで生存）を介すため同種の問題は無く、変更不要です。

## TDD

- `test/test_sim_dynamics.cpp`（新規）: 最小構成の `Simulation` で `do_step` を 50 ステップ実行。`-fsanitize=address` 下で**修正前は stack-use-after-scope で失敗（red）／修正後は成功（green）**。軌道が finite であることも検証。
- テスト基盤拡張: `test_sim_*` という名前のテストは `src/simulation.cpp` をリンクするようにし（`test/CMakeLists.txt` と `test/run_tests.sh`）、サニタイザ下で力学コードを検査可能に。

## ローカル再現手順

```sh
cmake -B build -DTROCHIA_BUILD_TESTS=ON -DTROCHIA_SANITIZE=ON
cmake --build build --target tests
ctest --test-dir build
```

## 変更ファイル

- `src/simulation.cpp` … `auto` → 具象型（修正本体）
- `test/test_sim_dynamics.cpp` … 新規テスト
- `test/CMakeLists.txt`, `test/run_tests.sh` … `test_sim_*` が `simulation.cpp` をリンク

## 影響

`sanitize` CI が `do_step` を ASan/UBSan 下で常時検査するようになり、この UB を恒久的にガードします。本修正は #37 の複数原因のうちの1つで、Engine のステートフルイテレータ UB・omega 未初期化などは後続の別 PR で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46