### PR TITLE
[fix] make Engine::thrust stateless (issue #37)

### DIFF
--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <vector>
 #include <utility>
+#include <algorithm>
 #include "math.hpp"
 
 // *data.begin() = (0.0,     thrust)
@@ -97,7 +98,6 @@ namespace trochia {
 			}
 
 			time_end = thrust.first;
-			itr = data.cbegin();
 
 			for(auto i=data.crbegin();i!=data.crend();i++){
 				if(i->second > this->thrust(time_max)*0.01){
@@ -123,40 +123,32 @@ namespace trochia {
 			return weight_total - weight_prop + prop;
 		}
 
-		auto thrust(const math::Float &time) -> math::Float {
-			const auto &next = itr+1;
-			const auto &time_now	= itr->first;
-			const auto &thrust_now	= itr->second;
-			const auto &time_next	= next->first;
-			const auto &thrust_next	= next->second;
-
+		// Linear-interpolate the thrust at the given time.
+		// Stateless (const) so it does not depend on call order and stays valid
+		// when the Engine is copied (the previous version advanced a member
+		// iterator and, after a Simulation copy, compared iterators from two
+		// different containers -- UB behind issue #37).
+		auto thrust(const math::Float &time) const -> math::Float {
+			if(data.empty())
+				return 0.0;
+			if(time <= data.front().first)
+				return data.front().second;
 			if(time >= time_end)		// thrust curve data is end
 				return 0.0;
 
-			// just time
-			if(time == time_now)
-				return thrust_now;
-			if(time == time_next){
-				itr++;
-				return itr->second;
-			}
+			// data is sorted by time; find the first point after `time`
+			const auto next = std::upper_bound(data.cbegin(), data.cend(), time,
+				[](const math::Float t, const thrust_t &p){ return t < p.first; });
+			if(next == data.cbegin() || next == data.cend())
+				return 0.0;
 
-			// linear interpolation
-			if(time_now < time && time < time_next){
-				const auto range	= time_next - time_now;
-				const auto elepsed	= time - time_now;
-				const auto progress	= elepsed / range;
-				return math::lerp(thrust_now, thrust_next, progress);
-			}
+			const auto &p0 = *(next-1);
+			const auto &p1 = *next;
+			const auto range = p1.first - p0.first;
+			if(range <= 0.0)			// coincident times: avoid divide-by-zero
+				return p0.second;
 
-			// update
-			if(time > time_next){
-				if(next != data.cend()-1)
-					itr++;
-				return thrust(time);
-			}
-
-			return 0.0;
+			return math::lerp(p0.second, p1.second, (time - p0.first) / range);
 		}
 	private:
 		// info
@@ -167,7 +159,6 @@ namespace trochia {
 
 		// thrustcurve
 		thrustcurve_t data;
-		thrustcurve_t::const_iterator itr;
 	public:
 		math::Float time_max, time_valid, time_end;
 	};

--- a/test/test_engine.cpp
+++ b/test/test_engine.cpp
@@ -1,0 +1,60 @@
+// Engine thrust-curve lookup must be correct and call-order independent.
+//
+// Regression test for issue #37: thrust() advanced a member iterator (stateful),
+// so the result depended on call order, load_eng left the iterator mid-curve,
+// and after a Simulation copy the iterator pointed into another container
+// (UB, heap-address dependent -> run-to-run nondeterminism).
+#include <gtest/gtest.h>
+#include <fstream>
+#include <string>
+#include "engine.hpp"
+
+using trochia::Engine;
+
+namespace {
+	// header: name diameter length delays prop_weight total_weight manufacturer
+	std::string write_eng() {
+		const std::string path = "/tmp/trochia_test_motor.eng";
+		std::ofstream o(path);
+		o << "TestMotor 24 70 P 0.1 0.2 Test\n"
+		  << "0.0 0.0\n"
+		  << "1.0 10.0\n"
+		  << "2.0 10.0\n"
+		  << "3.0 0.0\n";
+		return path;
+	}
+}
+
+class EngineTest : public ::testing::Test {
+protected:
+	Engine eng;
+	void SetUp() override { eng.load_eng(write_eng()); }
+};
+
+TEST_F(EngineTest, Interpolates) {
+	EXPECT_NEAR(eng.thrust(0.5), 5.0, 1e-9);   // between (0,0)-(1,10)
+	EXPECT_NEAR(eng.thrust(1.5), 10.0, 1e-9);  // flat top
+	EXPECT_NEAR(eng.thrust(2.5), 5.0, 1e-9);   // between (2,10)-(3,0)
+}
+
+TEST_F(EngineTest, ZeroAfterBurnout) {
+	EXPECT_NEAR(eng.thrust(3.0), 0.0, 1e-9);
+	EXPECT_NEAR(eng.thrust(10.0), 0.0, 1e-9);
+}
+
+// The crucial property: querying out of order yields identical results.
+TEST_F(EngineTest, CallOrderIndependent) {
+	const double a = eng.thrust(0.5);
+	eng.thrust(2.9);   // jump near the end
+	eng.thrust(0.1);   // jump back
+	const double b = eng.thrust(0.5);
+	EXPECT_DOUBLE_EQ(a, b);
+	EXPECT_NEAR(b, 5.0, 1e-9);
+}
+
+// A copied Engine must behave identically (Simulation copies it per case).
+TEST_F(EngineTest, CopyIsConsistent) {
+	const Engine copy = eng;
+	for (double t = 0.0; t <= 3.0; t += 0.13)
+		EXPECT_DOUBLE_EQ(copy.thrust(t), eng.thrust(t)) << "t=" << t;
+}


### PR DESCRIPTION
## 概要

issue #37（環境で計算結果が変わる）の原因の一つ、**`Engine::thrust` のステートフルなイテレータ**に起因する未定義動作・非決定性を修正します。

## 根本原因: メンバ `const_iterator itr` を進める実装

`thrust()` は推力履歴を走査するためにメンバの `const_iterator itr` を `++` していました。これが複数の問題を生みます。

1. **呼び出し順依存**: 結果が直前の呼び出しに依存。さらに `load_eng` の有効時間算出ループが `thrust(time_max)` を呼ぶため、**`itr` が曲線の途中（time_max 位置）に残ったまま**になり、飛翔開始直後の `thrust(小さい t)` が補間されず **0 を返す**。
2. **コピー後の UB（#37 の核心）**: `main.cpp` は条件ごとに `auto sim = sim_base;` で `Simulation` をコピーします。コピーされた `Engine` の `itr` は**コピー元 `sim_base` の `data` を指したまま**で、`thrust()` 内の `next != data.cend()-1` は**コピー側の `data`** と比較します。つまり**別コンテナのイテレータ同士を比較**＝UB。結果はヒープアドレス（ASLR）に依存し、**実行ごとに推力が変わり → 軌道が実行ごとに変わる**（#37 の run-to-run 非決定性）。
3. **終端外参照**: `itr` が最終点に達すると `next->first` が `data.cend()` を**デリファレンス**（範囲外読み）。

## 修正

`std::upper_bound`（二分探索）で**ステートレスに**推力を補間し、`const` 化します。メンバイテレータを廃止するので、**呼び出し順非依存・コピー安全・終端外参照なし**になります。

```cpp
auto thrust(const math::Float &time) const -> math::Float {
    if(data.empty()) return 0.0;
    if(time <= data.front().first) return data.front().second;
    if(time >= time_end) return 0.0;
    const auto next = std::upper_bound(data.cbegin(), data.cend(), time,
        [](const math::Float t, const thrust_t &p){ return t < p.first; });
    ...
    return math::lerp(p0.second, p1.second, (time - p0.first) / range);
}
```

## TDD（`test/test_engine.cpp`）

buggy 版での結果 → 本修正後:
- `Interpolates`: `thrust(0.5)` が **0（buggy）→ 5.0（fix）**。load_eng 後の itr 誤位置を露呈。
- `CallOrderIndependent`: 後方クエリが **0（buggy）→ 正値（fix）**。
- `CopyIsConsistent`: `const Engine copy` が同値を返す。**buggy ではコンパイル不可（thrust が非 const）→ fix で OK**。

## ローカル再現

```sh
cmake -B build -DTROCHIA_BUILD_TESTS=ON
cmake --build build --target tests
ctest --test-dir build
```

## 変更ファイル

- `src/engine.hpp` … `thrust()` をステートレス const 二分探索に、`itr` メンバ削除、`<algorithm>` 追加
- `test/test_engine.cpp` … 新規テスト

## 影響

`thrust()` の唯一の呼び出し元は `do_step` で、`const` 化後も問題なく動作します（テスト済み）。#37 の run-to-run 非決定性の一因を除去します。残る omega 未初期化等は後続 PR で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46