### PR TITLE
[fix] zero-initialise Object state (omega/domega/quat/time) (issue #37)

### DIFF
--- a/src/object.hpp
+++ b/src/object.hpp
@@ -31,10 +31,14 @@ namespace trochia::object {
 		Object() {}
 		Object(const Frame pos) : pos(pos) {}
 
-		math::Float time;
+		// NOTE: Eigen's default ctors do not zero-initialise. Without these
+		// in-class initialisers time/quat/omega/domega hold garbage, which is
+		// read before being set and produces undefined, platform/run-dependent
+		// results (issue #37).
+		math::Float time = 0.0;
 		Frame pos, vel, acc;
-		math::Quaternion quat;
-		math::Vector3 omega, domega;
+		math::Quaternion quat = math::Quaternion::Identity();
+		math::Vector3 omega = math::Vector3::Zero(), domega = math::Vector3::Zero();
 
 		static auto dx(const math::Float &t, const Object &x) -> const Object {
 			Object ret;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -69,6 +69,8 @@ auto trochia::simulation::exec(simulation::Simulation &sim) -> void {
 	pos.north(0.0);
 	rocket.vel.vec.setZero();
 	rocket.acc.vec.setZero();
+	rocket.omega.setZero();
+	rocket.domega.setZero();
 
 	rocket.quat = sim.launcher.get_angle();
 

--- a/test/test_object_init.cpp
+++ b/test/test_object_init.cpp
@@ -1,0 +1,40 @@
+// A freshly constructed Object must have a well-defined initial state.
+//
+// Regression test for issue #37: Object left time/quat/omega/domega
+// uninitialised (Eigen does not zero-initialise), and exec() never set omega,
+// so do_step read garbage angular velocity -> undefined, platform/run-dependent
+// attitude. We placement-new an Object over a buffer poisoned with 0xFF so any
+// member the constructor fails to initialise is deterministically non-zero.
+#include <gtest/gtest.h>
+#include <new>
+#include <cstring>
+#include "coordinate.hpp"
+#include "object.hpp"
+
+using Obj = trochia::object::Object<trochia::coordinate::local::NED>;
+
+TEST(ObjectInit, DefaultStateIsWellDefined) {
+	alignas(Obj) unsigned char buf[sizeof(Obj)];
+	std::memset(buf, 0xFF, sizeof(buf));
+
+	Obj *o = new (buf) Obj();
+
+	// angular velocity / its derivative must start at rest
+	EXPECT_DOUBLE_EQ(o->omega.x(), 0.0);
+	EXPECT_DOUBLE_EQ(o->omega.y(), 0.0);
+	EXPECT_DOUBLE_EQ(o->omega.z(), 0.0);
+	EXPECT_DOUBLE_EQ(o->domega.x(), 0.0);
+	EXPECT_DOUBLE_EQ(o->domega.y(), 0.0);
+	EXPECT_DOUBLE_EQ(o->domega.z(), 0.0);
+
+	// attitude must start as the identity rotation
+	EXPECT_DOUBLE_EQ(o->quat.w(), 1.0);
+	EXPECT_DOUBLE_EQ(o->quat.x(), 0.0);
+	EXPECT_DOUBLE_EQ(o->quat.y(), 0.0);
+	EXPECT_DOUBLE_EQ(o->quat.z(), 0.0);
+
+	// time must start at zero
+	EXPECT_DOUBLE_EQ(o->time, 0.0);
+
+	o->~Obj();
+}


### PR DESCRIPTION
## 概要

issue #37 の一因である **`Object` の未初期化メンバ**を修正します。

## 根本原因

`object::Object` は `time` / `quat` / `omega` / `domega` を**未初期化**のまま持っていました。Eigen のデフォルトコンストラクタは**ゼロ初期化しません**。さらに `exec()` は `vel`/`acc`/`quat` は設定するものの **`omega`/`domega` を初期化していません**。

その結果、`do_step` は**ゴミの角速度**を読み（`(Ka+Kj)*rocket.omega.y()`）、`dx` は**ゴミの `domega`** を読みます（`ret.omega = x.domega`）。このゴミが姿勢の数値積分を駆動するため、**未定義・環境/実行依存の軌道**になり、#37 の症状の一因になります。

※ AddressSanitizer は**未初期化読み出しを検出しません**（それは MSan の領域）。そのため本件はサニタイザ CI ではなく**専用テスト**でガードします。

## 修正

- `src/object.hpp`: in-class 初期化子（`time=0`, `quat=Identity`, `omega=Zero`, `domega=Zero`）。これで全 `Object` が既定で well-defined に。
- `src/simulation.cpp`: `exec()` でも `vel`/`acc` の隣で `omega`/`domega` をゼロ初期化（既存の明示初期化スタイルに合わせる）。

## TDD（`test/test_object_init.cpp`）

`0xFF` で汚染したバッファに `Object` を placement-new し、既定値を検証します。コンストラクタが初期化し損ねたメンバは決定的に非ゼロ（`-nan`）になります。
- 修正前: `omega`/`domega`/`quat`/`time` が **`-nan`（red）**
- 修正後: すべて 0 / 単位回転（**green**）

## ローカル再現

```sh
cmake -B build -DTROCHIA_BUILD_TESTS=ON
cmake --build build --target tests
ctest --test-dir build
```

## 変更ファイル

- `src/object.hpp` … メンバ初期化子
- `src/simulation.cpp` … `exec()` で omega/domega をゼロ初期化
- `test/test_object_init.cpp` … 新規テスト

## 影響

角速度・姿勢の初期状態が確定し、#37 の未初期化由来の非決定性を除去します。残る quaternion 順序・geodesy 符号・wind NaN 等は後続 PR で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46