### PR TITLE
[fix] correct geopotential-height sign

### DIFF
--- a/src/environment/earth/geodesy.hpp
+++ b/src/environment/earth/geodesy.hpp
@@ -34,7 +34,8 @@ namespace trochia::environment::earth::geodesy {
 		constexpr math::Float r0 = 6356766;
 		constexpr math::Float gamma = 1.0;
 
-		return (r0 * height) / (gamma * r0 - height);
+		// H = r0 * Z / (r0 + Z)  (geometric Z -> geopotential H)
+		return (r0 * height) / (gamma * r0 + height);
 	}
 }
 

--- a/test/test_geodesy.cpp
+++ b/test/test_geodesy.cpp
@@ -1,0 +1,26 @@
+// USSA1976 geopotential-height conversion.
+//
+// H = r0 * Z / (r0 + Z): geopotential height H is slightly *smaller* than the
+// geometric height Z. The code used (r0 - Z), which is the wrong sign.
+#include <gtest/gtest.h>
+#include "environment/earth/geodesy.hpp"
+
+using trochia::environment::earth::geodesy::potential_height;
+
+static constexpr double r0 = 6356766.0; // effective earth radius used by the model
+
+TEST(Geodesy, ZeroAtZero) {
+	EXPECT_NEAR(potential_height(0.0), 0.0, 1e-9);
+}
+
+// geopotential height is always slightly smaller than geometric height
+TEST(Geodesy, LessThanGeometric) {
+	for (const double z : {100.0, 1000.0, 10000.0, 50000.0})
+		EXPECT_LT(potential_height(z), z) << "z=" << z;
+}
+
+TEST(Geodesy, KnownValue10km) {
+	const double z = 10000.0;
+	const double expected = r0 * z / (r0 + z);   // ~= 9984.29 m
+	EXPECT_NEAR(potential_height(z), expected, 1e-6);
+}


### PR DESCRIPTION
## 概要

`geodesy::potential_height`（幾何高度 Z → ジオポテンシャル高度 H）の**符号誤り**を修正します。

## 根本原因

USSA1976 の関係式は **H = r0·Z / (r0 + Z)** ですが、コードは分母を `(r0 - Z)` としていました:
```cpp
return (r0 * height) / (gamma * r0 - height);   // 誤
```
このため H が幾何高度より**大きく**なり（Z→r0 で発散）、本来の **H < Z** と逆になります。ジオポテンシャル高度は大気モデル（気温・密度 → 抗力）に渡るため、軌道に影響します（標高が低いうちは差は小さいが系統誤差）。

## 修正

```cpp
return (r0 * height) / (gamma * r0 + height);
```

## TDD（`test/test_geodesy.cpp`）

- `LessThanGeometric`: Z>0 で H<Z。修正前は **H>Z（例: Z=10000 → 10015.8、red）**、修正後 9984.3（green）。
- `KnownValue10km`: H ≈ r0·Z/(r0+Z)。
- `ZeroAtZero`: H(0)=0。

## ローカル再現

```sh
cmake -B build -DTROCHIA_BUILD_TESTS=ON
cmake --build build --target tests
ctest --test-dir build
```

## 変更ファイル
- `src/environment/earth/geodesy.hpp` … 分母の符号 `-` → `+`
- `test/test_geodesy.cpp` … 新規テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46