### PR TITLE
[fix] guard wind::speed against negative altitude (NaN)

### DIFF
--- a/src/environment/wind.hpp
+++ b/src/environment/wind.hpp
@@ -28,6 +28,11 @@ namespace trochia::environment::wind {
 	using math::Float;
 	// 上空風速(べき法則)
 	inline auto speed(const Float n, const Float &z_r, const Float v_r, const Float altitude) -> math::Float {
+		// the power law is undefined at/below ground; wind is calm there.
+		// (avoids pow(negative, fractional) -> NaN, e.g. on the final descent step)
+		if(altitude <= Float(0.0))
+			return Float(0.0);
+
 		const auto tmp = altitude / z_r;
 		return v_r * std::pow(tmp, Float(1.0) / n);
 	}

--- a/test/test_wind.cpp
+++ b/test/test_wind.cpp
@@ -1,0 +1,30 @@
+// Power-law wind profile.
+//
+// speed(n, z_r, v_r, altitude) = v_r * (altitude / z_r)^(1/n).
+// At/below ground the profile must stay finite: pow(negative, fractional) is NaN.
+#include <gtest/gtest.h>
+#include <cmath>
+#include "environment/wind.hpp"
+
+using trochia::environment::wind::speed;
+
+TEST(Wind, ReferenceHeight) {
+	// at altitude == reference height the speed equals the reference speed
+	EXPECT_NEAR(speed(6.0, 2.0, 5.0, 2.0), 5.0, 1e-9);
+}
+
+TEST(Wind, KnownValue) {
+	// (128/2)^(1/6) = 64^(1/6) = 2  ->  5 * 2 = 10
+	EXPECT_NEAR(speed(6.0, 2.0, 5.0, 128.0), 10.0, 1e-9);
+}
+
+TEST(Wind, GroundZero) {
+	EXPECT_NEAR(speed(6.0, 2.0, 5.0, 0.0), 0.0, 1e-9);
+}
+
+// below ground (e.g. the final descent step) the wind must not become NaN
+TEST(Wind, NegativeAltitudeFinite) {
+	const double v = speed(6.0, 2.0, 5.0, -1.0);
+	EXPECT_FALSE(std::isnan(v));
+	EXPECT_NEAR(v, 0.0, 1e-12);
+}


### PR DESCRIPTION
## 概要

`wind::speed`（べき法則の上空風）が **負の高度で NaN** を返す問題を修正します。

## 根本原因

```cpp
return v_r * std::pow(altitude / z_r, 1.0 / n);
```
`altitude < 0` だと `pow(負, 分数)` となり **NaN**。`do_step` は現在高度でこれを呼ぶため、**着地直前に高度がわずかに負**になる瞬間に NaN の風速が生じ、対気速度・空力の計算を汚染します。

## 修正

べき法則は地表以下では未定義なので、`altitude <= 0` では **0（無風）** を返します。

```cpp
if(altitude <= Float(0.0)) return Float(0.0);
```

## TDD（`test/test_wind.cpp`）

- `NegativeAltitudeFinite`: `speed(...,-1)` が有限（==0）。**修正前は NaN（red）／修正後 0（green）**。
- `ReferenceHeight` / `KnownValue` / `GroundZero`: プロファイル本体の値も検証。

## ローカル再現

```sh
cmake -B build -DTROCHIA_BUILD_TESTS=ON
cmake --build build --target tests
ctest --test-dir build
```

## 変更ファイル
- `src/environment/wind.hpp` … `altitude<=0` ガード
- `test/test_wind.cpp` … 新規テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46