### PR TITLE
[fix] correct quaternion kinematics ordering in Object::dx (issue #37)

### DIFF
--- a/src/object.hpp
+++ b/src/object.hpp
@@ -48,13 +48,17 @@ namespace trochia::object {
 			ret.omega = x.domega;
 
 			// http://www.mss.co.jp/technology/report/pdf/18-07.pdf 4.3.2
+			// q_dot = 0.5 * Omega(omega) * q for body angular rates.
+			// quat2vec/vec2quat use the scalar-first ordering [w, x, y, z], so
+			// Omega must be the scalar-first form (the scalar-last matrix gives a
+			// wrong attitude derivative -- issue #37).
 			const auto &omg = x.omega;
 			math::Matrix4 mat;
 			mat <<
-				0.0,			omg(2),			-1.0*omg(1),	omg(0),
-				-1.0*omg(2),	0.0,			omg(0),			omg(1),
-				omg(1),			-1.0*omg(0),	0.0,			omg(2),
-				-1.0*omg(0),	-1.0*omg(1),	-1.0*omg(2),	0.0;
+				0.0,			-1.0*omg(0),	-1.0*omg(1),	-1.0*omg(2),
+				omg(0),			0.0,			omg(2),			-1.0*omg(1),
+				omg(1),			-1.0*omg(2),	0.0,			omg(0),
+				omg(2),			omg(1),			-1.0*omg(0),	0.0;
 
 			math::Vector4 dq = 0.5 * mat * math::quat2vec(x.quat);
 

--- a/test/test_object_dynamics.cpp
+++ b/test/test_object_dynamics.cpp
@@ -1,0 +1,64 @@
+// Quaternion kinematics in Object::dx.
+//
+// Regression test for issue #37: dq/dt must be 0.5 * (q (x) omega_quat) for
+// body angular rates (Hamilton product). quat2vec/vec2quat use the scalar-first
+// ordering [w,x,y,z], but dx used the scalar-last Omega matrix, so the attitude
+// derivative was wrong (a "[fix] quaternion" earlier only added the 0.5 factor,
+// not the ordering).
+#include <gtest/gtest.h>
+#include "coordinate.hpp"
+#include "object.hpp"
+
+using trochia::math::Quaternion;
+using trochia::math::Vector3;
+using Obj = trochia::object::Object<trochia::coordinate::local::NED>;
+
+namespace { constexpr double tol = 1e-12; }
+
+// For the identity quaternion, dq vector part = 0.5*omega, scalar part 0.
+TEST(ObjectDx, IdentityQuatRateX) {
+	Obj o; o.quat = Quaternion(1, 0, 0, 0); o.omega = Vector3(2.0, 0, 0);
+	const auto d = Obj::dx(0.0, o);
+	EXPECT_NEAR(d.quat.w(), 0.0, tol);
+	EXPECT_NEAR(d.quat.x(), 1.0, tol);
+	EXPECT_NEAR(d.quat.y(), 0.0, tol);
+	EXPECT_NEAR(d.quat.z(), 0.0, tol);
+}
+
+TEST(ObjectDx, IdentityQuatRateZ) {
+	Obj o; o.quat = Quaternion(1, 0, 0, 0); o.omega = Vector3(0, 0, 2.0);
+	const auto d = Obj::dx(0.0, o);
+	EXPECT_NEAR(d.quat.w(), 0.0, tol);
+	EXPECT_NEAR(d.quat.x(), 0.0, tol);
+	EXPECT_NEAR(d.quat.y(), 0.0, tol);
+	EXPECT_NEAR(d.quat.z(), 1.0, tol);
+}
+
+// General case: dq must equal 0.5 * (q (x) omega_quat), computed via Eigen.
+TEST(ObjectDx, MatchesHamiltonProduct) {
+	Obj o;
+	const Quaternion q(0.5, 0.5, 0.5, 0.5); // unit quaternion
+	const Vector3 w(0.3, -0.7, 1.1);
+	o.quat = q; o.omega = w;
+
+	const auto d = Obj::dx(0.0, o);
+
+	const Quaternion wq(0.0, w.x(), w.y(), w.z());
+	const Quaternion prod = q * wq; // Hamilton product
+
+	EXPECT_NEAR(d.quat.w(), 0.5 * prod.w(), tol);
+	EXPECT_NEAR(d.quat.x(), 0.5 * prod.x(), tol);
+	EXPECT_NEAR(d.quat.y(), 0.5 * prod.y(), tol);
+	EXPECT_NEAR(d.quat.z(), 0.5 * prod.z(), tol);
+}
+
+// Rotation preserves the quaternion norm: q . q_dot = 0.
+TEST(ObjectDx, NormPreserved) {
+	Obj o;
+	const Quaternion q(0.5, 0.5, 0.5, 0.5);
+	o.quat = q; o.omega = Vector3(0.3, -0.7, 1.1);
+	const auto d = Obj::dx(0.0, o);
+	const double dot = q.w()*d.quat.w() + q.x()*d.quat.x()
+		+ q.y()*d.quat.y() + q.z()*d.quat.z();
+	EXPECT_NEAR(dot, 0.0, tol);
+}


### PR DESCRIPTION
## 概要

`Object::dx` の**クォータニオン運動学の成分順序の誤り**を修正します。

## 根本原因

姿勢の時間微分は、機体角速度 ω に対して **q̇ = 0.5 · Ω(ω) · q**。`quat2vec`/`vec2quat` はクォータニオンを**スカラ先頭 `[w, x, y, z]`** で詰めますが、`dx` の Ω 行列は**スカラ末尾 `[x, y, z, w]` 用**の形でした。そのため姿勢微分が誤っていました。

（過去の `[fix] quaternion` は**欠けていた 0.5 係数を足しただけ**で、順序ミスは残存していました。）

## 検証

Eigen の Hamilton 積で確認: 単位クォータニオン q と機体角速度 ω に対し、`dx(q,ω).quat` は **0.5 · (q ⊗ (0,ω))** に一致すべき。Ω 行列をスカラ先頭形に置き換えます（0.5 は既存）。

```cpp
mat <<
    0.0,     -ωx,  -ωy,  -ωz,
    ωx,       0,    ωz,  -ωy,
    ωy,      -ωz,   0,    ωx,
    ωz,       ωy,  -ωx,   0;
dq = 0.5 * mat * quat2vec(x.quat);   // quat2vec = [w,x,y,z]
```

## TDD（`test/test_object_dynamics.cpp`）

- `IdentityQuatRateX/Z`: 単位クォータニオンで dq のベクトル部 = 0.5·ω、スカラ部 0。
- `MatchesHamiltonProduct`: 一般の q, ω で `dq == 0.5·(q⊗(0,ω))`（Eigen で独立計算）。
- いずれも**修正前は失敗（red）／修正後 green**。
- `NormPreserved`（q·q̇=0）は Ω が歪対称なので順序に依らず成立（sanity）。

## ローカル再現

```sh
cmake -B build -DTROCHIA_BUILD_TESTS=ON
cmake --build build --target tests
ctest --test-dir build
```

## 変更ファイル
- `src/object.hpp` … Ω 行列をスカラ先頭形に
- `test/test_object_dynamics.cpp` … 新規テスト

## 影響

姿勢の数値積分が正しくなります（従来は誤った軸・向きで回転）。#37 の姿勢由来の挙動を是正します。なお moment(`ma_y`)の符号は別途、正しい姿勢規約のもとで再検証して対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKBVgTqjZV84zcMVY3w46