### PR TITLE
fix: correct aerodynamic pitching-moment (ma_y) sign

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -225,7 +225,7 @@ auto trochia::simulation::do_step(Simulation &sim, solver::solver<rocket::Rocket
 
 	// rotation
 	const auto lcp_lcg = rocket.lcp - rocket.lcg();					// length of CG~CP
-	const auto ma_y = lcp_lcg*rocket.N + (Ka+Kj)*rocket.omega.y();	// Aerodynamic moment around Y axis
+	const auto ma_y = -1.0*lcp_lcg*rocket.N + (Ka+Kj)*rocket.omega.y();	// Aerodynamic moment around Y axis
 	const auto ma_z = lcp_lcg*rocket.Y + (Ka+Kj)*rocket.omega.z();	// Aerodynamic moment around Z axis
 
 	const auto I = rocket.inertia();				// Moment of Inertia

--- a/test/test_sim_dynamics.cpp
+++ b/test/test_sim_dynamics.cpp
@@ -58,9 +58,22 @@ TEST(SimDynamics, DoStepStaysFinite) {
 	// a non-trivial upward velocity so the airspeed vector is exercised
 	sim.rocket.vel.vec = math::Vector3(0.0, 0.0, -30.0); // NED: down is +, so up
 
+	const double start_alt = sim.rocket.pos.altitude();
+
 	for (int i = 0; i < 50; ++i) {
 		trochia::simulation::do_step(sim, solve);
 		ASSERT_TRUE(std::isfinite(sim.rocket.pos.altitude())) << "altitude NaN at step " << i;
 		ASSERT_TRUE(std::isfinite(sim.rocket.vel.vec.norm())) << "velocity NaN at step " << i;
+
+		// The launch is wholly in the East-Up plane: azimuth 90 deg, wind along
+		// the E axis (wind_dir -90), initial velocity straight up. Nothing forces
+		// out-of-plane (north) motion, so north must stay zero. Issue #37's
+		// uninitialised state and tumble leaked numerical noise into a growing
+		// out-of-plane drift -- a finiteness check alone would not have caught it.
+		EXPECT_NEAR(sim.rocket.pos.north(), 0.0, 1e-9)
+			<< "out-of-plane (north) drift at step " << i;
 	}
+
+	// 500 N thrust on a 5 kg rocket plus the initial 30 m/s climb: altitude must grow.
+	EXPECT_GT(sim.rocket.pos.altitude(), start_alt) << "rocket did not ascend under thrust";
 }

--- a/test/test_sim_stability.cpp
+++ b/test/test_sim_stability.cpp
@@ -1,0 +1,135 @@
+// Stability regression test for the aerodynamic pitching-moment sign (issue #37).
+//
+// A statically stable rocket (centre of pressure aft of centre of gravity,
+// lcp > lcg) must produce a *restoring* aerodynamic moment: an angle of attack
+// induced by the wind has to be driven back towards zero (weathercocking), so
+// during powered ascent the angle of attack stays small and bounded.
+//
+// The moment about the body Y axis was written with the wrong sign
+//     ma_y =  lcp_lcg * N          // de-stabilising
+// instead of
+//     ma_y = -lcp_lcg * N          // restoring
+// which turns the moment anti-restoring: any disturbance is amplified and the
+// rocket tumbles. The fix is verified empirically here (issue author's chosen
+// approach) rather than by re-deriving the sign convention by hand.
+//
+// Measured max |AoA| during ascent (to apogee), per (elevation, wind):
+//     wrong sign : ~179-180 deg  (full tumble; apogee collapses to ~130-170 m)
+//     fixed sign :    4-16 deg   (weathercocks; apogee ~390-440 m)
+// The 45 deg threshold sits with >3x margin below the stable cases and far
+// below the ~180 deg tumble, so this fails (red) on the wrong sign and passes
+// (green) on the fix.
+//
+// NOTE: only the ascent to apogee is examined. On the ballistic descent the
+// body still points up while the velocity points down, so AoA legitimately
+// approaches 180 deg even for a perfectly stable rocket -- that is not a tumble.
+#include <gtest/gtest.h>
+#include <cmath>
+#include <fstream>
+#include <string>
+#include "simulation.hpp"
+#include "solver.hpp"
+
+using namespace trochia;
+
+namespace {
+	std::string write_eng() {
+		const std::string path = "/tmp/trochia_test_stability.eng";
+		std::ofstream o(path);
+		o << "TestMotor 112 1150 P 1.0 2.0 Test\n"
+		  << "0.0 0.0\n"
+		  << "0.1 500.0\n"
+		  << "1.0 500.0\n"
+		  << "2.0 0.0\n";
+		return path;
+	}
+
+	simulation::Simulation make_sim(double elevation, double wind) {
+		simulation::Simulation sim;
+		sim.dt         = 0.01;
+		sim.wind_speed = wind;
+		sim.wind_dir   = -90.0;                 // wind along the E axis (in-plane)
+		sim.launcher   = environment::Launcher(5.0, 90.0, elevation); // azimuth East
+
+		auto &r = sim.rocket;
+		r.diameter = 0.112; r.length = 1.15; r.mass = 5.0;
+		r.lcg0 = 0.90; r.lcgf = 0.90; r.lcgp = 1.00; r.lcp = 1.10; // CP aft of CG
+		r.I0 = 1.2; r.If = 1.2; r.Cd = 0.44; r.Cna = 7.84;
+		r.engine.load_eng(write_eng());
+		r.Cmq = -1.0 * r.Cna / 2.0 * std::pow((r.lcp - r.lcg0) / r.length, 2.0);
+
+		r.time = 0.0;
+		r.pos.vec.setZero();
+		r.vel.vec.setZero();
+		r.acc.vec.setZero();
+		r.omega.setZero();
+		r.domega.setZero();
+		r.quat = sim.launcher.get_angle();
+		return sim;
+	}
+
+	struct AscentResult {
+		double max_aoa_deg = 0.0;   // max |AoA| during ascent after launch clear
+		double max_north   = 0.0;   // max |north| (should stay ~0 in-plane)
+		double apogee      = 0.0;
+		bool   finite      = true;
+	};
+
+	// Integrate from the rail until apogee, tracking the stability metrics.
+	AscentResult fly_to_apogee(simulation::Simulation &sim) {
+		auto solve = solver::RK4(sim.rocket, rocket::Rocket::dx);
+		AscentResult res;
+		bool cleared = false;
+		double prev_alt = -1e9;
+		for (int i = 0; i < 5000; ++i) {       // hard cap as a backstop
+			simulation::do_step(sim, solve);
+			const auto &r = sim.rocket;
+			const coordinate::local::NED p = r.pos;
+			if (!std::isfinite(p.altitude()) || !std::isfinite(r.vel.vec.norm())) {
+				res.finite = false;
+				break;
+			}
+			const double aoa = std::fabs(math::rad2deg(r.angle_attack));
+			res.max_north = std::max(res.max_north, std::fabs(p.north()));
+			if (p.vec.norm() > sim.launcher.length) cleared = true;
+			const bool ascending = p.altitude() > prev_alt;
+			if (cleared && ascending) {
+				res.max_aoa_deg = std::max(res.max_aoa_deg, aoa);
+				res.apogee = std::max(res.apogee, p.altitude());
+			}
+			if (cleared && !ascending) break;  // apogee reached
+			prev_alt = p.altitude();
+		}
+		return res;
+	}
+}
+
+// During powered ascent a statically stable rocket weathercocks into the wind
+// and the angle of attack stays small. The wrong moment sign tumbles it to
+// ~180 deg, which this catches.
+class SimStability : public ::testing::TestWithParam<std::pair<double, double>> {};
+
+TEST_P(SimStability, AngleOfAttackStaysBoundedDuringAscent) {
+	const auto [elevation, wind] = GetParam();
+	auto sim = make_sim(elevation, wind);
+	const auto res = fly_to_apogee(sim);
+
+	ASSERT_TRUE(res.finite) << "trajectory went non-finite (elev=" << elevation
+	                        << ", wind=" << wind << ")";
+	// restoring moment -> bounded AoA; anti-restoring (wrong sign) -> ~180 deg
+	EXPECT_LT(res.max_aoa_deg, 45.0)
+		<< "rocket appears to tumble during ascent (max AoA " << res.max_aoa_deg
+		<< " deg) at elev=" << elevation << ", wind=" << wind
+		<< " -- aerodynamic pitching moment is not restoring";
+	// in-plane launch (azimuth East, wind along E): no out-of-plane forcing
+	EXPECT_LT(res.max_north, 1e-6)
+		<< "out-of-plane (north) motion " << res.max_north
+		<< " m appeared in a symmetric in-plane case";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	Configs, SimStability,
+	::testing::Values(
+		std::make_pair(89.0, 3.0),
+		std::make_pair(85.0, 3.0),
+		std::make_pair(80.0, 5.0)));


### PR DESCRIPTION
## 概要

機体 Y 軸まわりの空力ピッチングモーメントの**符号が誤っていた**ため、静的に安定な機体（CP が CG より後方, `lcp > lcg`）でも擾乱が増幅されてタンブルしていました。issue #37（Windows/Linux・gcc/clang で結果が異なる）の根本原因のうち、use-after-scope・未初期化・quaternion 順序の修正後に残っていた**最後の1つ**です。

```diff
-const auto ma_y =  lcp_lcg*rocket.N + (Ka+Kj)*rocket.omega.y();  // 反安定
+const auto ma_y = -1.0*lcp_lcg*rocket.N + (Ka+Kj)*rocket.omega.y();  // 復元
```

静安定な機体では、迎角によって生じるモーメントは迎角を**減らす向き（復元・風見安定）**でなければなりません。誤符号ではこれが反転し、わずかな擾乱が増幅されて機体が回転してしまいます。

## 妥当性（実測＋第一原理の一致）

- **第一原理 (`r × F`)**: 力は `Body(T-D, -Y, -N)`。body +x が機首方向で CP は CG 後方なので CP のオフセットは `rx = -lcp_lcg`。よって `M_y = -rx·Fz = -lcp_lcg·N`（=本修正）。同じ理屈で yaw 側 `M_z = rx·Fy = +lcp_lcg·Y` は**既に正しい**ため変更しません。
- **実測（安定性検証）**: 手計算で符号規約を再導出するのではなく、issue 起票者の選んだ方針どおり**安定性テストで経験的に検証**しました。

| 符号 | 上昇中 max 迎角 | 頂点高度 |
|---|---|---|
| 誤 (`+`) | **~179–180°（タンブル）** | ~130–170 m |
| 正 (`-`, 本修正) | **4–16°（風見安定で収束）** | ~390–440 m |

## テスト

取り込まれる変更の詳細はコミットを参照してください。

- **`test/test_sim_stability.cpp`（新規・本命）**: 風のある全飛行を頂点まで積分し（力・モーメント・quaternion・RK4 の全結合ダイナミクスを通る）、上昇中の迎角が有界であることを検証。複数の (仰角, 風速) で parameterized。**誤符号で red → 修正で green** を確認済み。
  - 注: 弾道降下では機体は上向き・速度は下向きで迎角が物理的に ~180° へ近づく（タンブルではない）ため、判定は**上昇フェーズ（頂点まで）**に限定。
- **`test/test_sim_dynamics.cpp`（強化）**: 従来の「有限であること」に加え、**対称面不変量（azimuth=東・風=東西・初速=鉛直上 なので北方向≈0）** と **推力下で高度が増加すること** を検証。sanitizer に頼らずに挙動を守れるようにしました。

## 確認

- `test/run_tests.sh`・CMake/ctest（26 テスト）・ASan/UBSan すべて green。
- `ma_z`（yaw）は導出上すでに正しいため未変更。

closes #37
