### PR TITLE
[add] launch-rail normal-force constraint

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -241,8 +241,18 @@ auto trochia::simulation::do_step(Simulation &sim, solver::solver<rocket::Rocket
 		//rocket.omega.y() += domg_y * sim.dt;
 		//rocket.omega.z() += domg_z * sim.dt;
 	}else{
+		// On the launch rail (issue #32): the rail constrains the rocket to its
+		// axis, reacting every force perpendicular to it (the rail normal force,
+		// 垂直抗力) and any moment. So zero the rotation and keep only the
+		// along-rail component of the acceleration. Without this, the
+		// perpendicular component of gravity (a tilted rail) and the spurious
+		// low-speed angle of attack push the rocket off the rail.
 		rocket.domega.setZero();
 		rocket.omega.setZero();
+
+		const math::Vector3 rail = coordinate::dcm::body2ned(rocket.quat)
+			* math::Vector3(1.0, 0.0, 0.0);	// rail axis (body +x) in NED
+		rocket.acc.vec = rail * rocket.acc.vec.dot(rail);
 	}
 
 	// update

--- a/test/test_sim_rail.cpp
+++ b/test/test_sim_rail.cpp
@@ -1,0 +1,104 @@
+// Launch-rail constraint test (issue #32: "ランチャをランチャにする").
+//
+// While the rocket is still on the launch rail it is mechanically constrained
+// to the rail axis: the rail reacts every force perpendicular to itself (the
+// normal reaction / 垂直抗力), so the rocket may only translate along the rail.
+//
+// Before the fix only the rotation was frozen on the rail; the translational
+// equations still applied the full 3-DOF force. The perpendicular component of
+// gravity (a tilted rail) and the spurious low-speed angle of attack therefore
+// pushed the rocket sideways off the rail before it cleared:
+//     elevation 80 deg : ~0.15 m off-axis at launch clear
+//     elevation 85 deg : ~0.07 m
+// With the constraint the off-axis displacement is machine-zero (~1e-15 m) while
+// the along-rail launch-clear velocity is unchanged. This catches a regression
+// (red ~0.15 m -> green ~0) and is independent of the moment-sign physics.
+#include <gtest/gtest.h>
+#include <cmath>
+#include <fstream>
+#include <string>
+#include "simulation.hpp"
+#include "solver.hpp"
+#include "coordinate.hpp"
+
+using namespace trochia;
+
+namespace {
+	std::string write_eng() {
+		const std::string path = "/tmp/trochia_test_rail.eng";
+		std::ofstream o(path);
+		o << "TestMotor 112 1150 P 1.0 2.0 Test\n"
+		  << "0.0 0.0\n"
+		  << "0.1 500.0\n"
+		  << "1.0 500.0\n"
+		  << "2.0 0.0\n";
+		return path;
+	}
+
+	simulation::Simulation make_sim(double elevation, double wind) {
+		simulation::Simulation sim;
+		sim.dt         = 0.01;
+		sim.wind_speed = wind;
+		sim.wind_dir   = -90.0;
+		sim.launcher   = environment::Launcher(5.0, 90.0, elevation);
+
+		auto &r = sim.rocket;
+		r.diameter = 0.112; r.length = 1.15; r.mass = 5.0;
+		r.lcg0 = 0.90; r.lcgf = 0.90; r.lcgp = 1.00; r.lcp = 1.10;
+		r.I0 = 1.2; r.If = 1.2; r.Cd = 0.44; r.Cna = 7.84;
+		r.engine.load_eng(write_eng());
+		r.Cmq = -1.0 * r.Cna / 2.0 * std::pow((r.lcp - r.lcg0) / r.length, 2.0);
+
+		r.time = 0.0;
+		r.pos.vec.setZero();
+		r.vel.vec.setZero();
+		r.acc.vec.setZero();
+		r.omega.setZero();
+		r.domega.setZero();
+		r.quat = sim.launcher.get_angle();
+		return sim;
+	}
+}
+
+// The rocket must ride the rail exactly until it clears it.
+class SimRail : public ::testing::TestWithParam<std::pair<double, double>> {};
+
+TEST_P(SimRail, StaysOnRailUntilLaunchClear) {
+	const auto [elevation, wind] = GetParam();
+	auto sim = make_sim(elevation, wind);
+	auto solve = solver::RK4(sim.rocket, rocket::Rocket::dx);
+
+	// rail axis (body +x at the launcher attitude) expressed in NED
+	const math::Vector3 rail =
+		coordinate::dcm::body2ned(sim.launcher.get_angle()) * math::Vector3(1.0, 0.0, 0.0);
+
+	double max_perp = 0.0;
+	bool cleared = false;
+	double clear_speed = 0.0;
+	for (int i = 0; i < 1000; ++i) {
+		simulation::do_step(sim, solve);
+		const auto &r = sim.rocket;
+		if (r.pos.vec.norm() > sim.launcher.length) {
+			cleared = true;
+			clear_speed = r.vel.vec.norm();
+			break;
+		}
+		// distance from the rail line = component of position perpendicular to rail
+		const math::Vector3 p = r.pos.vec;
+		const math::Vector3 perp = p - rail * p.dot(rail);
+		max_perp = std::max(max_perp, perp.norm());
+	}
+
+	ASSERT_TRUE(cleared) << "rocket never left the rail (elev=" << elevation
+	                     << ", wind=" << wind << ")";          // guards against a trivial pass
+	EXPECT_LT(max_perp, 1e-9)
+		<< "rocket drifted " << max_perp << " m off the rail axis while still on the rail"
+		<< " (elev=" << elevation << ", wind=" << wind << ")";
+	EXPECT_GT(clear_speed, 1.0) << "implausibly small launch-clear speed";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	Configs, SimRail,
+	::testing::Values(
+		std::make_pair(85.0, 3.0),
+		std::make_pair(80.0, 5.0)));


### PR DESCRIPTION
## 概要

issue #32「ランチャをランチャにする」の残りの項目 **垂直抗力** を実装します。

レール上の機体は機械的にレール軸へ拘束され、レールに垂直な力はすべてレールが受け止めます（垂直抗力）。よって機体は**レール軸方向にしか並進できない**はずですが、従来は回転を止めるだけで並進は 3 自由度の力をそのまま適用していました。その結果、**傾けたレールでの重力の垂直成分**と**低速時の見かけ上の迎角**によって、ランチクリア前に機体が横へずれていました（仰角 80° で実測 **~0.15 m**)。

```cpp
// レール上: レール軸方向の加速度成分のみ残す（垂直成分はレールが受ける）
const math::Vector3 rail = coordinate::dcm::body2ned(rocket.quat)
        * math::Vector3(1.0, 0.0, 0.0);   // レール軸 (body +x) を NED で
rocket.acc.vec = rail * rocket.acc.vec.dot(rail);
```

修正後、レールからの横ずれは機械精度（~1e-15 m）になり、**レール軸方向のランチクリア速度は不変**（25.1 m/s）です。

## issue #32 チェックリストの対応
- [x] ランチャに刺さってるかどうかの判定 — `is_launch_clear()`（既存）
- [x] **垂直抗力 — 本 PR**
- [x] ランチクリア速度の出力 — `launch_clear.second`（既存、`exec()` で出力済み）

## テスト

取り込まれる変更の詳細はコミットを参照してください。

- **`test/test_sim_rail.cpp`（新規）**: 複数の (仰角, 風速) でレール上を積分し、**ランチクリアまで機体がレール軸上に留まる**ことを検証（レール軸への垂直距離）。
  - **red（拘束なし）→ 軸から 0.07–0.15 m ずれて FAIL / green（拘束あり）→ ~1e-15 m で PASS** を確認済み。
  - 「ランチクリアに到達し、妥当なクリア速度が出る」ことも assert し、機体が動かないことによる**トリビアルな pass を防止**。

## 確認
- `test/run_tests.sh`・CMake/ctest（**28 テスト**）・ASan/UBSan すべて green。
- レール後のダイナミクス（#56 の安定性テスト等）に影響なし（クリア速度不変）。

closes #32
