### PR TITLE
[fix] skip ';' comment lines when parsing .eng files

### DIFF
--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -24,6 +24,7 @@
 
 #include <iostream>
 #include <string>
+#include <sstream>
 #include <fstream>
 #include <vector>
 #include <utility>
@@ -46,8 +47,19 @@ namespace trochia {
 			std::ifstream ifs(fname);
 			if(!ifs) return;
 
+			// RASP .eng files (e.g. every ThrustCurve.org export) begin with
+			// ';' comment lines; strip comment and blank lines before parsing
+			// so the header is read from the first real line.
+			std::stringstream ss;
+			for(std::string line; std::getline(ifs, line); ){
+				const auto p = line.find_first_not_of(" \t\r\n");
+				if(p == std::string::npos || line[p] == ';')
+					continue;
+				ss << line << '\n';
+			}
+
 			std::string delays;
-			ifs >> name >> diameter >> length
+			ss >> name >> diameter >> length
 				>> delays
 				>> weight_prop >> weight_total
 				>> manufacturer;
@@ -69,8 +81,8 @@ namespace trochia {
 			double thrust_max = 0.0;
 
 			// load thrust curve
-			while(ifs){
-				ifs >> t >> th;
+			while(ss){
+				ss >> t >> th;
 				if(t < thrust.first)			// unsorted data
 					break;
 

--- a/test/test_engine.cpp
+++ b/test/test_engine.cpp
@@ -58,3 +58,26 @@ TEST_F(EngineTest, CopyIsConsistent) {
 	for (double t = 0.0; t <= 3.0; t += 0.13)
 		EXPECT_DOUBLE_EQ(copy.thrust(t), eng.thrust(t)) << "t=" << t;
 }
+
+// Real .eng files (e.g. every ThrustCurve.org export) begin with ';' comment
+// lines. The header must be read from the first non-comment line, not from the
+// ';' line.
+TEST(EngineComments, SkipsRaspCommentLines) {
+	const std::string path = "/tmp/trochia_test_motor_comments.eng";
+	{
+		std::ofstream o(path);
+		o << "; Estes A8 RASP.ENG file made from NAR published data\n"
+		  << "; File produced March 3, 2011\n"
+		  << ";\n"
+		  << "TestMotor 24 70 P 0.1 0.2 Test\n"
+		  << "0.0 0.0\n"
+		  << "1.0 10.0\n"
+		  << "2.0 10.0\n"
+		  << "3.0 0.0\n";
+	}
+	Engine eng;
+	eng.load_eng(path);
+	EXPECT_NEAR(eng.thrust(0.5), 5.0, 1e-9);   // interpolated, proves header parsed
+	EXPECT_NEAR(eng.thrust(1.5), 10.0, 1e-9);
+	EXPECT_NEAR(eng.weight(0.0), 0.2, 1e-9);   // total weight from the header line
+}


### PR DESCRIPTION
## 概要

`Engine::load_eng` がモーターヘッダをファイル先頭行から読んでいましたが、標準的な RASP `.eng`（**ThrustCurve.org の全エクスポートを含む**）は先頭に `;` コメント行があります:

```
; Estes A8 RASP.ENG file made from NAR published data
; File produced March 3, 2011
 A8 18 70 0 .00384 .01389 E
0.016 1.080
...
```

このため `;` 行をヘッダとして誤読し、`name=";"`・質量0・推力曲線が壊れ、**推力ゼロ＝機体が飛びませんでした**。プロジェクト同梱モーターはたまたま gist にコメントが無く動いていただけです。

## 修正
パース前に `;` コメント行・空行を除去（stringstream 経由）。残りのローダは不変。これで trochia は ThrustCurve の `.eng` を**そのまま読めます**。

## TDD（red→green）
`test/test_engine.cpp` の `EngineComments.SkipsRaspCommentLines`: コメント付きヘッダを書き、推力曲線と total weight が正しく読めることを検証（修正前 red → 修正後 green）。

## 確認
- `test/run_tests.sh` 全 30 テスト green。
- 実機確認: ThrustCurve の Estes A8（コメント付き）を直接読み込み、`name=A8 / total 0.01389 / max thrust 9.56N` を正しく取得。

> note: これは検証 example（実在ロケットで精度検証）の前提となる修正です。example 本体は別 PR で作成します。
