### PR TITLE
[add] simulation contingency-scenario branching

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -38,3 +38,21 @@ Cna		= 7.840
 # parachute: deploys at apogee ("top") + delay [s]; cd and diameter [m] set the
 # drag (omit cd/diameter for a ballistic descent with no recovery)
 parachute= {condition = "top", delay = 2.5, cd = 1.5, diameter = 1.5}
+
+# Optional contingency scenarios (failure branches). Each [[scenario]] is run as
+# its own flight; with more than one the output nests under output/<name>/.
+# Without any, a single nominal flight is run.
+#   recovery = "none"   -> parachute does not deploy (recovery failure, ballistic)
+#   motor_cutoff = <s>  -> thrust stops after t (airframe intact, still recovers)
+#   cato = <s>          -> structural failure at t (thrust stops AND no recovery)
+# [[scenario]]
+# name = "nominal"
+# [[scenario]]
+# name = "chute-failure"
+# recovery = "none"
+# [[scenario]]
+# name = "motor-cutoff"
+# motor_cutoff = 3.0
+# [[scenario]]
+# name = "cato"
+# cato = 3.0

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -40,6 +40,7 @@ auto load(const std::string &fname, simulation::Simulation &sim) -> Conditions {
 	cond_elevation	launcher_elevation;
 	cond_wspeed		wind_speed;
 	cond_wdir		wind_dir;
+	cond_scenario	scenarios;
 
 	const auto config = parse(fname);
 
@@ -154,7 +155,27 @@ auto load(const std::string &fname, simulation::Simulation &sim) -> Conditions {
 		}
 	}
 
-	return {launcher_elevation, wind_speed, wind_dir};
+	// contingency scenarios (optional). Each [[scenario]] is a failure branch;
+	// without any, a single nominal flight is run.
+	if(config.contains("scenario")){
+		const auto arr = find<std::vector<toml::table>>(config, "scenario");
+		for(const auto &s : arr){
+			simulation::Scenario sc;
+			if(s.count("name"))
+				sc.name = s.at("name").as_string();
+			if(s.count("recovery"))
+				sc.recovery_fail = (s.at("recovery").as_string() == "none");
+			if(s.count("motor_cutoff"))
+				sc.motor_cutoff = as_number(s.at("motor_cutoff"));
+			if(s.count("cato"))
+				sc.cato = as_number(s.at("cato"));
+			scenarios.push_back(sc);
+		}
+	}
+	if(scenarios.empty())
+		scenarios.push_back(simulation::Scenario{});	// nominal
+
+	return {launcher_elevation, wind_speed, wind_dir, scenarios};
 }
 
 }

--- a/src/io/config.hpp
+++ b/src/io/config.hpp
@@ -30,7 +30,8 @@ namespace trochia::io::config {
 	using cond_elevation= std::vector<double>;
 	using cond_wspeed	= std::vector<double>;
 	using cond_wdir		= std::vector<double>;
-	using Conditions	= std::tuple<cond_elevation, cond_wspeed, cond_wdir>;
+	using cond_scenario	= std::vector<simulation::Scenario>;
+	using Conditions	= std::tuple<cond_elevation, cond_wspeed, cond_wdir, cond_scenario>;
 
 	auto load(const std::string &fname, simulation::Simulation &sim) -> Conditions;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,20 +59,27 @@ auto main(int argc, char **argv) -> int {
 	const std::string config_path = (argc > 1) ? argv[1] : "config.toml";
 
 	std::cerr << "loading config file " << config_path << " ...";
-	const auto [elevation, wind_speed, wind_dir]
+	const auto [elevation, wind_speed, wind_dir, scenarios]
 		= trochia::io::config::load(config_path, sim_base);
 	std::cerr << std::endl;
 
 	std::cerr << "start simulation" << std::endl;
 
 	std::cout << "sim number: "
-		<< elevation.size()*wind_speed.size()*wind_dir.size() << std::endl;
+		<< elevation.size()*wind_speed.size()*wind_dir.size()*scenarios.size() << std::endl;
 
 	const auto output_base_dir = fs::path(sim_base.output_dir_fmt);
 
+	// with multiple contingency scenarios, nest the output under each scenario
+	// name; a single (nominal) scenario keeps the original output layout.
+	const bool multi_scenario = scenarios.size() > 1;
+
+	for(const auto &scenario : scenarios){
+	const auto scenario_base = multi_scenario ? (output_base_dir / scenario.name) : output_base_dir;
+
 	for(const auto &e : elevation){
 		const auto e_str = shrink_str(to_string(e));
-		const auto e_dir = output_base_dir / e_str;
+		const auto e_dir = scenario_base / e_str;
 
 		const auto launcher = trochia::environment::Launcher(5.0, 150.0, e);
 
@@ -94,6 +101,7 @@ auto main(int argc, char **argv) -> int {
 				sim.launcher	= launcher;
 				sim.wind_speed	= ws;
 				sim.wind_dir	= wd;
+				sim.scenario	= scenario;
 
 				trochia::simulation::exec(sim);
 
@@ -110,6 +118,7 @@ auto main(int argc, char **argv) -> int {
 			}
 		}
 	}
+	}	// scenario
 
 	return 0;
 }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -192,7 +192,13 @@ auto trochia::simulation::do_step(Simulation &sim, solver::solver<rocket::Rocket
 	if(!rocket.apogee_time
 			&& is_launch_clear(sim.launcher, sim.rocket) && vel_ned.vec.z() > 0.0)
 		rocket.apogee_time = time;
-	if(!rocket.chute_open && rocket.para_cd > 0.0 && rocket.para_area > 0.0
+	// recovery fails on a chute-failure scenario, or once a CATO has occurred
+	// (a CATO at/after its time also destroys an already-open chute) -> ballistic
+	const bool cato_now = sim.scenario.cato && time >= *sim.scenario.cato;
+	if(cato_now)
+		rocket.chute_open = false;
+	const bool recovery_ok = !sim.scenario.recovery_fail && !cato_now;
+	if(!rocket.chute_open && recovery_ok && rocket.para_cd > 0.0 && rocket.para_area > 0.0
 			&& rocket.apogee_time && time >= *rocket.apogee_time + rocket.para_delay)
 		rocket.chute_open = true;
 
@@ -226,8 +232,9 @@ auto trochia::simulation::do_step(Simulation &sim, solver::solver<rocket::Rocket
 	if(rocket.N > rocket.N_max)
 		rocket.N_max	= rocket.N;
 
-	// thrust
-	const auto thrust = rocket.engine.thrust(time); // first stage only
+	// thrust (first stage only); a motor-cutoff or CATO scenario kills it after t
+	const auto cutoff = sim.scenario.cato ? sim.scenario.cato : sim.scenario.motor_cutoff;
+	const auto thrust = (cutoff && time >= *cutoff) ? 0.0 : rocket.engine.thrust(time);
 
 	const auto force = coordinate::body::Body(
 		thrust - rocket.D,

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -24,6 +24,8 @@
 
 #include <utility>
 #include <string>
+#include <vector>
+#include <optional>
 #include <filesystem>
 #include <fstream>
 #include "math.hpp"
@@ -33,6 +35,15 @@
 
 namespace trochia::simulation {
 	using math::Float;
+
+	// A contingency branch to simulate (failure-mode scenarios). The nominal
+	// flight is the default; the fields override it to model a failure.
+	struct Scenario {
+		std::string name = "nominal";
+		bool recovery_fail = false;        // parachute does not deploy -> ballistic
+		std::optional<Float> motor_cutoff; // thrust = 0 after t [s] (airframe intact)
+		std::optional<Float> cato;         // structural failure at t [s]: thrust=0 + no recovery
+	};
 
 	class Simulation {
 	public:
@@ -48,6 +59,8 @@ namespace trochia::simulation {
 		Float launcher_angle;
 
 		Float wind_speed, wind_dir;
+
+		Scenario scenario;	// active contingency branch (default: nominal)
 
 		rocket::Rocket rocket;
 

--- a/test/test_sim_scenario.cpp
+++ b/test/test_sim_scenario.cpp
@@ -1,0 +1,112 @@
+// Contingency-scenario branching: the same flight simulated under different
+// failure modes (parachute failure -> ballistic, early motor cutoff, CATO).
+#include <gtest/gtest.h>
+#include <cmath>
+#include <fstream>
+#include <string>
+#include "simulation.hpp"
+#include "solver.hpp"
+#include "coordinate.hpp"
+
+using namespace trochia;
+
+namespace {
+	std::string write_eng() {
+		const std::string path = "/tmp/trochia_test_scenario.eng";
+		std::ofstream o(path);
+		o << "TestMotor 112 1150 P 1.0 2.0 Test\n"
+		  << "0.0 0.0\n0.1 500.0\n1.0 500.0\n2.0 0.0\n";
+		return path;
+	}
+
+	simulation::Simulation make_sim() {
+		simulation::Simulation sim;
+		sim.dt = 0.01; sim.wind_speed = 2.0; sim.wind_dir = 90.0;
+		sim.launcher = environment::Launcher(5.0, 90.0, 89.0);
+		auto &r = sim.rocket;
+		r.diameter = 0.112; r.length = 1.15; r.mass = 5.0;
+		r.lcg0 = 0.90; r.lcgf = 0.90; r.lcgp = 1.00; r.lcp = 1.10;
+		r.I0 = 1.2; r.If = 1.2; r.Cd = 0.44; r.Cna = 7.84;
+		r.engine.load_eng(write_eng());
+		r.Cmq = -1.0 * r.Cna / 2.0 * std::pow((r.lcp - r.lcg0) / r.length, 2.0);
+		r.para_cd = 1.5; r.para_area = math::pi * 1.0 * 1.0 / 4.0; r.para_delay = 0.0;
+		r.time = 0.0;
+		r.pos.vec.setZero(); r.vel.vec.setZero(); r.acc.vec.setZero();
+		r.omega.setZero(); r.domega.setZero();
+		r.quat = sim.launcher.get_angle();
+		return sim;
+	}
+
+	struct Outcome { double apogee, landing_speed; bool chute_open; };
+
+	Outcome fly(const simulation::Scenario &sc) {
+		auto sim = make_sim();
+		sim.scenario = sc;
+		auto solve = solver::RK4(sim.rocket, rocket::Rocket::dx);
+		Outcome o{0.0, 0.0, false};
+		for (int i = 0; i < 200000; ++i) {
+			simulation::do_step(sim, solve);
+			const coordinate::local::NED p = sim.rocket.pos;
+			o.apogee = std::max(o.apogee, p.altitude());
+			if (p.vec.norm() > sim.launcher.length && p.altitude() <= 0.0) {
+				o.landing_speed = sim.rocket.vel.vec.norm();
+				o.chute_open = sim.rocket.chute_open;
+				break;
+			}
+		}
+		return o;
+	}
+}
+
+TEST(SimScenario, NominalDeploysChute) {
+	const auto nom = fly(simulation::Scenario{});
+	EXPECT_TRUE(nom.chute_open) << "nominal flight should deploy the chute";
+}
+
+// Recovery failure: the chute is configured but does not deploy -> ballistic,
+// so the landing is far faster than the nominal (chute) descent.
+TEST(SimScenario, RecoveryFailureIsBallistic) {
+	const auto nom = fly(simulation::Scenario{});
+	simulation::Scenario f; f.name = "chute-failure"; f.recovery_fail = true;
+	const auto fail = fly(f);
+
+	EXPECT_FALSE(fail.chute_open) << "recovery failure must not deploy the chute";
+	EXPECT_GT(fail.landing_speed, 3.0 * nom.landing_speed)
+		<< "ballistic landing (" << fail.landing_speed
+		<< ") should be far faster than chute landing (" << nom.landing_speed << ")";
+}
+
+// Early motor cutoff delivers less impulse -> lower apogee.
+TEST(SimScenario, MotorCutoffLowersApogee) {
+	const auto nom = fly(simulation::Scenario{});
+	simulation::Scenario c; c.name = "motor-cutoff"; c.motor_cutoff = 0.5;
+	const auto cut = fly(c);
+
+	EXPECT_LT(cut.apogee, nom.apogee) << "cutoff at 0.5 s should lower the apogee";
+	EXPECT_TRUE(cut.chute_open) << "an intact airframe still recovers after a cutoff";
+}
+
+// CATO: structural failure -> thrust stops and no recovery (ballistic, low).
+TEST(SimScenario, CatoIsLowAndBallistic) {
+	const auto nom = fly(simulation::Scenario{});
+	simulation::Scenario c; c.name = "cato"; c.cato = 0.5;
+	const auto cato = fly(c);
+
+	EXPECT_LT(cato.apogee, nom.apogee)      << "CATO at 0.5 s should lower the apogee";
+	EXPECT_FALSE(cato.chute_open)           << "CATO disables recovery";
+	// ballistic (no chute), though slower than a full-impulse fall since the
+	// early cutoff gives a much lower apogee
+	EXPECT_GT(cato.landing_speed, 2.0 * nom.landing_speed) << "CATO descent is ballistic";
+}
+
+// A CATO after the chute has already deployed must destroy it -> revert to
+// ballistic (recovery is only honoured up to the CATO time, not from t=0).
+TEST(SimScenario, CatoAfterDeploymentRevertsToBallistic) {
+	const auto nom = fly(simulation::Scenario{});       // full chute descent
+	simulation::Scenario c; c.name = "late-cato"; c.cato = 12.0;  // after apogee+deploy
+	const auto late = fly(c);
+
+	EXPECT_FALSE(late.chute_open) << "CATO must destroy an already-open chute";
+	EXPECT_GT(late.landing_speed, 3.0 * nom.landing_speed)
+		<< "after the CATO the descent is ballistic again";
+}


### PR DESCRIPTION
## 概要

実打ち上げは通常飛行だけでなく**失敗分岐**があり、各分岐の落下区域が安全審査で重要です。**同一飛行を複数のコンティンジェンシーで実行する分岐機構**を追加します。

## config: `[[scenario]]` 配列
各分岐は通常飛行を上書き:
- `recovery = "none"` … パラシュート未展開（回収失敗 → 弾道）
- `motor_cutoff = <s>` … 指定時刻で推力カット（機体は健全、回収は機能）
- `cato = <s>` … 構造破壊（推力停止＋回収無効 → 弾道）

`[[scenario]]` 無しなら従来通り単一の nominal を実行。**2つ以上**なら出力を `output/<name>/...` にネスト（既存の単一シナリオ config/examples のレイアウトは不変）。

## 実装
- `simulation.hpp`: `Scenario` 構造体、`Simulation` が active scenario を保持。
- config: `[[scenario]]` を parse（elevation/wind スイープと共に返す）。
- `do_step`: motor_cutoff/cato で推力を時刻後 0、recovery_fail/cato で chute 展開を抑止。
- `main`: シナリオを最外ループ化。

## TDD（test/test_sim_scenario.cpp）
nominal は chute 展開／回収失敗は弾道（着地が大幅に速い）／motor-cutoff は低 apogee だが回収する／CATO は低 apogee かつ弾道。

## 確認
- 全 37 テスト green。
- バイナリ end-to-end: 4 シナリオの config が 4 つの落下区域を生成。例（仰角80・東風4 m/s）:
  - nominal: GHP (203, −10) — chute で風下 ~200m
  - chute-failure: GHP (15, −20) — 弾道で射点近傍
  - motor-cutoff(0.3s): apogee 11m、chute → GHP (49, −3)
  - cato(0.3s): apogee 11m、弾道 → GHP (4, −5)

> note: この機構を使い、次の km example（PSAS Launch-12）で通常回収＋失敗の両落下区域を可視化します。
