### PR TITLE
[add] multi-stage parachute recovery (drogue + main + ...)

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -35,9 +35,18 @@ lcgp	= 1.076
 lcp		= 1.141
 Cd		= 0.440
 Cna		= 7.840
-# parachute: deploys at apogee ("top") + delay [s]; cd and diameter [m] set the
-# drag (omit cd/diameter for a ballistic descent with no recovery)
-parachute= {condition = "top", delay = 2.5, cd = 1.5, diameter = 1.5}
+# Recovery: one or more parachute stages (omit entirely for a ballistic descent).
+# Each stage has cd and diameter [m]; it deploys either at apogee (+ optional
+# delay [s]) or, if it has an `altitude` [m AGL], when descending through it.
+#
+# single chute at apogee:
+parachute= {delay = 2.5, cd = 1.5, diameter = 1.5}
+#
+# or dual deployment (drogue at apogee, main lower down) -- any number of stages:
+# parachute = [
+#     {delay = 0.0, cd = 1.2, diameter = 0.5},     # drogue at apogee
+#     {altitude = 300, cd = 1.5, diameter = 3.0},  # main at 300 m AGL
+# ]
 
 # Optional contingency scenarios (failure branches). Each [[scenario]] is run as
 # its own flight; with more than one the output nests under output/<name>/.

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -141,17 +141,42 @@ auto load(const std::string &fname, simulation::Simulation &sim) -> Conditions {
 		sim.rocket.Cd = stage[0].at("Cd").as_floating();
 		sim.rocket.Cna= stage[0].at("Cna").as_floating();
 
-		// parachute (optional): cd + diameter -> drag area; deploys at apogee+delay.
+		// recovery: one or more parachute stages. `parachute` may be a single
+		// inline table or an array of tables (drogue, main, ...). A stage with an
+		// `altitude` deploys at that AGL on the way down; otherwise it deploys at
+		// apogee (+ optional `delay`). cd + diameter set its drag.
+		sim.rocket.parachutes.clear();	// overwrite, so load() is idempotent
 		if(stage[0].contains("parachute")){
-			const auto &para = stage[0].at("parachute");
-			if(para.contains("cd"))
-				sim.rocket.para_cd = as_number(para.at("cd"));
-			if(para.contains("diameter")){
-				const auto d = as_number(para.at("diameter"));
-				sim.rocket.para_area = math::pi * d * d / 4.0;
-			}
-			if(para.contains("delay"))
-				sim.rocket.para_delay = as_number(para.at("delay"));
+			const auto parse_chute = [](const toml::value &t) -> rocket::Parachute {
+				rocket::Parachute p;
+				if(t.contains("altitude"))
+					p.altitude = as_number(t.at("altitude"));
+				else {
+					p.at_apogee = true;
+					if(t.contains("delay"))
+						p.delay = as_number(t.at("delay"));
+				}
+				if(t.contains("cd"))
+					p.cd = as_number(t.at("cd"));
+				if(t.contains("diameter")){
+					const auto d = as_number(t.at("diameter"));
+					p.area = math::pi * d * d / 4.0;
+				}
+				return p;
+			};
+			// only keep stages that actually have drag (cd>0 and a diameter);
+			// an incomplete stage means no recovery (ballistic), as before.
+			const auto add_chute = [&](const toml::value &t){
+				const auto p = parse_chute(t);
+				if(p.cd > 0.0 && p.area > 0.0)
+					sim.rocket.parachutes.push_back(p);
+			};
+			const auto &pc = stage[0].at("parachute");
+			if(pc.is_array())
+				for(const auto &t : pc.as_array())
+					add_chute(t);
+			else
+				add_chute(pc);
 		}
 	}
 

--- a/src/rocket.hpp
+++ b/src/rocket.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 #include "math.hpp"
 #include "coordinate.hpp"
 #include "engine.hpp"
@@ -33,6 +34,19 @@
 
 namespace trochia::rocket {
 	using LocalFrame = coordinate::local::NED;
+
+	// One recovery stage. Any number of these can be chained (drogue, main, ...).
+	// A stage deploys at apogee+delay (at_apogee) or when descending through
+	// `altitude` (AGL). While any stage is open the rocket descends under the
+	// summed chute drag.
+	struct Parachute {
+		bool at_apogee = false;             // deploy at apogee + delay
+		math::Float delay = 0.0;            // [s] after apogee
+		std::optional<math::Float> altitude;// else deploy at this altitude AGL [m] on descent
+		math::Float cd = 0.0;               // drag coefficient
+		math::Float area = 0.0;             // reference area [m^2]
+		bool open = false;                  // runtime: deployed?
+	};
 
 	class Rocket : public object::Object<LocalFrame> {
 	public:
@@ -58,15 +72,23 @@ namespace trochia::rocket {
 
 		math::Float va_max=0.0, N_max=0.0;
 
-		// parachute / recovery. para_cd<=0 or para_area<=0 means no parachute
-		// (the rocket descends ballistically). The chute deploys at apogee plus
-		// para_delay; once open the body aerodynamics/rotation are dropped and
-		// the rocket descends under chute drag, drifting with the wind.
-		math::Float para_cd    = 0.0;	// parachute drag coefficient
-		math::Float para_area  = 0.0;	// parachute reference area [m^2]
-		math::Float para_delay = 0.0;	// deploy delay after apogee [s]
-		bool chute_open = false;	// runtime: is the chute deployed?
+		// recovery: any number of parachute stages (empty -> ballistic descent).
+		// While any stage is open the body aero/rotation are dropped and the
+		// rocket descends under the summed chute drag, drifting with the wind.
+		std::vector<Parachute> parachutes;
 		std::optional<math::Float> apogee_time;	// runtime: set when the climb turns to descent
+
+		// is any recovery stage deployed?
+		auto chute_open() const -> bool {
+			for(const auto &p : parachutes) if(p.open) return true;
+			return false;
+		}
+		// summed drag area (Cd*A) of the open stages
+		auto chute_cda() const -> math::Float {
+			math::Float s = 0.0;
+			for(const auto &p : parachutes) if(p.open) s += p.cd * p.area;
+			return s;
+		}
 
 		static auto dx(const math::Float &t, const Rocket &r) -> const Rocket {
 			return object::Object<LocalFrame>::dx(t, r);

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -72,7 +72,8 @@ auto trochia::simulation::exec(simulation::Simulation &sim) -> void {
 	rocket.omega.setZero();
 	rocket.domega.setZero();
 
-	rocket.chute_open = false;	// recovery state, reset per case
+	for(auto &p : rocket.parachutes)	// recovery state, reset per case
+		p.open = false;
 	rocket.apogee_time.reset();
 
 	rocket.quat = sim.launcher.get_angle();
@@ -193,24 +194,35 @@ auto trochia::simulation::do_step(Simulation &sim, solver::solver<rocket::Rocket
 			&& is_launch_clear(sim.launcher, sim.rocket) && vel_ned.vec.z() > 0.0)
 		rocket.apogee_time = time;
 	// recovery fails on a chute-failure scenario, or once a CATO has occurred
-	// (a CATO at/after its time also destroys an already-open chute) -> ballistic
+	// (a CATO at/after its time also destroys any deployed chute) -> ballistic
 	const bool cato_now = sim.scenario.cato && time >= *sim.scenario.cato;
 	if(cato_now)
-		rocket.chute_open = false;
+		for(auto &p : rocket.parachutes) p.open = false;
 	const bool recovery_ok = !sim.scenario.recovery_fail && !cato_now;
-	if(!rocket.chute_open && recovery_ok && rocket.para_cd > 0.0 && rocket.para_area > 0.0
-			&& rocket.apogee_time && time >= *rocket.apogee_time + rocket.para_delay)
-		rocket.chute_open = true;
+	// deploy each recovery stage when its trigger is met: at apogee+delay, or
+	// when descending through its altitude (AGL) -- supports any number of stages
+	// (drogue, main, ...).
+	if(recovery_ok && rocket.apogee_time){
+		for(auto &p : rocket.parachutes){
+			if(p.open)
+				continue;
+			if(p.at_apogee){
+				if(time >= *rocket.apogee_time + p.delay) p.open = true;
+			}else if(p.altitude){
+				if(vel_ned.vec.z() > 0.0 && rocket.pos.altitude() <= *p.altitude) p.open = true;
+			}
+		}
+	}
 
 	// Under the parachute the rocket hangs from the canopy: drop the body
-	// aerodynamics and rotation, and descend under chute drag (which opposes the
-	// air-relative velocity, so the rocket drifts with the wind). This is what
-	// makes the landing footprint realistic for a recovered flight.
-	if(rocket.chute_open){
+	// aerodynamics and rotation, and descend under the summed chute drag (which
+	// opposes the air-relative velocity, so the rocket drifts with the wind).
+	// This is what makes the landing footprint realistic for a recovered flight.
+	if(rocket.chute_open()){
 		const math::Vector3 va_c = vel_ned.vec - wind_ned;
 		const math::Float   vmag = va_c.norm();
 		const math::Vector3 drag = -0.5 * sim.rho * vmag
-			* rocket.para_cd * rocket.para_area * va_c;	// = -0.5 rho |v| Cd A v
+			* rocket.chute_cda() * va_c;	// = -0.5 rho |v| (sum Cd A) v
 		rocket.acc.vec = drag / rocket.weight();
 		if(rocket.pos.altitude() > 0.0)
 			rocket.acc.down(rocket.acc.down() + environment::gravity(rocket.pos.altitude()));

--- a/test/test_sim_parachute.cpp
+++ b/test/test_sim_parachute.cpp
@@ -42,9 +42,9 @@ namespace {
 		r.engine.load_eng(write_eng());
 		r.Cmq = -1.0 * r.Cna / 2.0 * std::pow((r.lcp - r.lcg0) / r.length, 2.0);
 
-		r.para_cd = 1.5;
-		r.para_area = math::pi * 1.0 * 1.0 / 4.0;   // 1.0 m diameter
-		r.para_delay = 0.0;
+		// single chute at apogee, 1.0 m diameter
+		r.parachutes.push_back(rocket::Parachute{
+			.at_apogee = true, .delay = 0.0, .cd = 1.5, .area = math::pi * 1.0 * 1.0 / 4.0});
 
 		r.time = 0.0;
 		r.pos.vec.setZero();
@@ -62,7 +62,7 @@ namespace {
 		r.pos.vec.setZero();
 		r.pos.up(altitude);
 		r.vel.vec.setZero();
-		r.chute_open = true;
+		r.parachutes[0].open = true;
 		r.apogee_time = 0.0;   // already past apogee
 	}
 }
@@ -79,7 +79,7 @@ TEST(SimParachute, ReachesTerminalVelocity) {
 
 	const double W  = sim.rocket.weight();
 	const double g  = 9.80665;   // gravity at ~km altitude differs <0.1% from g0
-	const double vt = std::sqrt(2.0 * W * g / (sim.rho * sim.rocket.para_cd * sim.rocket.para_area));
+	const double vt = std::sqrt(2.0 * W * g / (sim.rho * sim.rocket.chute_cda()));
 
 	const coordinate::local::NED v = sim.rocket.vel;
 	EXPECT_GT(v.vec.z(), 0.0) << "should be descending (NED down +)";
@@ -106,11 +106,48 @@ TEST(SimParachute, DriftsWithWind) {
 	EXPECT_GT(v.vec.y(), 0.7 * wind) << "horizontal velocity should approach the wind speed";
 }
 
+// Dual deployment: a small drogue at apogee (fast descent) then a large main at
+// a set altitude (slow descent) -- the descent rate drops once the main opens.
+TEST(SimParachute, DualDeployFastUnderDrogueThenSlowUnderMain) {
+	auto sim = make_sim();
+	auto &r = sim.rocket;
+	r.parachutes.clear();
+	r.parachutes.push_back(rocket::Parachute{           // drogue at apogee (small)
+		.at_apogee = true, .delay = 0.0, .cd = 1.2, .area = math::pi * 0.3 * 0.3 / 4.0});
+	r.parachutes.push_back(rocket::Parachute{           // main at 300 m AGL (large)
+		.altitude = 300.0, .cd = 1.5, .area = math::pi * 2.0 * 2.0 / 4.0});
+	r.pos.vec.setZero(); r.pos.up(900.0);
+	r.vel.vec.setZero();
+	r.apogee_time = 0.0;
+	r.parachutes[0].open = true;                        // drogue already out
+
+	auto solve = solver::RK4(sim.rocket, rocket::Rocket::dx);
+	double v_drogue = 0.0, v_main = 0.0;
+	bool main_seen = false;
+	for (int i = 0; i < 200000; ++i) {
+		simulation::do_step(sim, solve);
+		const coordinate::local::NED p = sim.rocket.pos;
+		const double alt = p.altitude(), vz = sim.rocket.vel.vec.z();
+		if (alt > 500.0 && alt < 700.0) v_drogue = vz;  // under drogue only
+		if (sim.rocket.parachutes[1].open) {
+			main_seen = true;
+			if (alt > 100.0 && alt < 250.0) v_main = vz; // under drogue + main
+		}
+		if (p.vec.norm() > sim.launcher.length && alt <= 0.0) break;
+	}
+	EXPECT_TRUE(main_seen) << "the main should deploy below its altitude";
+	EXPECT_GT(v_drogue, 0.0);
+	EXPECT_GT(v_main, 0.0);
+	EXPECT_GT(v_drogue, 1.5 * v_main)
+		<< "drogue descent (" << v_drogue << ") should be faster than under the main ("
+		<< v_main << ")";
+}
+
 // Deploying the chute makes the rocket land far slower than a ballistic fall.
 TEST(SimParachute, DeploymentSlowsDescentVsBallistic) {
 	auto landing_speed = [](bool with_chute) {
 		auto sim = make_sim();
-		if (!with_chute) sim.rocket.para_cd = 0.0;   // ballistic
+		if (!with_chute) sim.rocket.parachutes.clear();   // ballistic
 		auto solve = solver::RK4(sim.rocket, rocket::Rocket::dx);
 		double speed = 0.0;
 		for (int i = 0; i < 100000; ++i) {
@@ -121,7 +158,7 @@ TEST(SimParachute, DeploymentSlowsDescentVsBallistic) {
 				break;
 			}
 		}
-		return std::make_pair(speed, sim.rocket.chute_open);
+		return std::make_pair(speed, sim.rocket.chute_open());
 	};
 
 	const auto [v_chute, opened] = landing_speed(true);

--- a/test/test_sim_scenario.cpp
+++ b/test/test_sim_scenario.cpp
@@ -29,7 +29,8 @@ namespace {
 		r.I0 = 1.2; r.If = 1.2; r.Cd = 0.44; r.Cna = 7.84;
 		r.engine.load_eng(write_eng());
 		r.Cmq = -1.0 * r.Cna / 2.0 * std::pow((r.lcp - r.lcg0) / r.length, 2.0);
-		r.para_cd = 1.5; r.para_area = math::pi * 1.0 * 1.0 / 4.0; r.para_delay = 0.0;
+		r.parachutes.push_back(rocket::Parachute{
+			.at_apogee = true, .delay = 0.0, .cd = 1.5, .area = math::pi * 1.0 * 1.0 / 4.0});
 		r.time = 0.0;
 		r.pos.vec.setZero(); r.vel.vec.setZero(); r.acc.vec.setZero();
 		r.omega.setZero(); r.domega.setZero();
@@ -50,7 +51,7 @@ namespace {
 			o.apogee = std::max(o.apogee, p.altitude());
 			if (p.vec.norm() > sim.launcher.length && p.altitude() <= 0.0) {
 				o.landing_speed = sim.rocket.vel.vec.norm();
-				o.chute_open = sim.rocket.chute_open;
+				o.chute_open = sim.rocket.chute_open();
 				break;
 			}
 		}


### PR DESCRIPTION
## 概要

単一パラシュート（issue #6）を **任意段数のリカバリ段**に一般化します。実機の dual-deploy（頂点でドローグ → 低高度でメイン）やそれ以上の段数をモデル化できます。OpenRocket の降下が速いのも、まさにこの drogue→低 main 構成のためでした。

## モデル
- **rocket**: 固定 `para_*` を `std::vector<Parachute>` に変更。各 `Parachute` は **頂点+delay**（`at_apogee`）または **指定高度(AGL)で降下中**（`altitude`）に展開。`chute_open()`/`chute_cda()` が開いている段とその `Cd·A` 合算を返す。
- **config**: `parachute` は **単一インラインテーブル（従来通り・後方互換）** または **テーブルの配列**。`altitude` があれば高度トリガ、無ければ頂点トリガ(+delay)。

```toml
# 単段（頂点）
parachute = {delay = 2.5, cd = 1.5, diameter = 1.5}

# 多段（ドローグ + メイン）— 段数は任意
parachute = [
    {delay = 0.0, cd = 1.2, diameter = 0.5},     # ドローグ（頂点）
    {altitude = 300, cd = 1.5, diameter = 3.0},  # メイン（300 m AGL）
]
```

- **do_step**: 各段をトリガで展開、開いている段の抗力を合算して降下。CATO/回収失敗は全段を閉じる（弾道）＝従来通り。

## TDD
`test/test_sim_parachute.cpp` の `DualDeployFastUnderDrogueThenSlowUnderMain`: 頂点で小ドローグ→300 m で大メイン、**メイン展開で降下速度が低下**することを検証。既存の単段・シナリオテストはベクタモデルに移植済みで全て pass。

## 確認
- 全 24→25 テスト green（多段テスト追加）。
- バイナリ end-to-end: 単一インラインテーブル（後方互換）と配列（多段）の両方が parse・動作。
