### PR TITLE
Configure launch rail length and azimuth from config

### DIFF
--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -64,6 +64,13 @@ auto load(const std::string &fname, simulation::Simulation &sim) -> Conditions {
 	{
 		const auto &cfg_launcher = find(config, "launcher");
 
+		// optional rail length [m] and azimuth [deg]. Omitted -> historical
+		// hardcoded defaults (5 m, 150 deg); see Simulation::make_launcher.
+		if(cfg_launcher.contains("length"))
+			sim.launcher_length = as_number(cfg_launcher.at("length"));
+		if(cfg_launcher.contains("azimuth"))
+			sim.launcher_azimuth = as_number(cfg_launcher.at("azimuth"));
+
 		// get elevation
 		const auto elevation = find(cfg_launcher, "elevation");
 		if(elevation.is_integer())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,7 @@ auto main(int argc, char **argv) -> int {
 		const auto e_str = shrink_str(to_string(e));
 		const auto e_dir = scenario_base / e_str;
 
-		const auto launcher = trochia::environment::Launcher(5.0, 150.0, e);
+		const auto launcher = sim_base.make_launcher(e);
 
 		std::vector<trochia::simulation::Simulation::GHP> ghp_table;
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -56,7 +56,11 @@ namespace trochia::simulation {
 
 		// input value
 		environment::Launcher launcher;
-		Float launcher_angle;
+		// launch rail, from the config [launcher] table. Defaults preserve the
+		// historical hardcoded rail (5 m, azimuth 150 deg) when the config omits
+		// them; elevation is swept per run and supplied to make_launcher().
+		Float launcher_length  = 5.0;
+		Float launcher_azimuth = 150.0;
 
 		Float wind_speed, wind_dir;
 
@@ -76,6 +80,12 @@ namespace trochia::simulation {
 			Float max_altitude;
 		};
 		GHP ghp_local;
+
+		// Build the launch rail for a given elevation [deg] from the configured
+		// length and azimuth. main.cpp calls this once per swept elevation.
+		auto make_launcher(const Float &elevation_deg) const -> environment::Launcher {
+			return environment::Launcher(launcher_length, launcher_azimuth, elevation_deg);
+		}
 	};
 
 	auto exec(Simulation &sim) -> void;

--- a/test/test_launcher_config.cpp
+++ b/test/test_launcher_config.cpp
@@ -1,0 +1,35 @@
+// The launch rail's length and azimuth come from the config ([launcher] length
+// / azimuth). main.cpp builds the Launcher for each swept elevation via
+// Simulation::make_launcher(); these tests pin that mapping, including the
+// backward-compatible defaults used when the config omits the fields.
+#include <gtest/gtest.h>
+#include "simulation.hpp"
+
+using namespace trochia;
+
+namespace {
+	// quat<->euler round-trips cleanly away from the 90-deg gimbal singularity.
+	constexpr double TOL = 1e-4;
+}
+
+// Without launcher.length / launcher.azimuth in the config, keep the historical
+// hardcoded behaviour (5 m rail, 150 deg azimuth).
+TEST(LauncherConfig, DefaultsMatchLegacyHardcode) {
+	simulation::Simulation sim;
+	auto l = sim.make_launcher(70.0);
+	EXPECT_DOUBLE_EQ(l.length, 5.0);
+	EXPECT_NEAR(l.azimuth(),   150.0, TOL);
+	EXPECT_NEAR(l.elevation(),  70.0, TOL);
+}
+
+// Configured rail length and azimuth flow through to the constructed Launcher,
+// with the swept elevation applied per run.
+TEST(LauncherConfig, HonorsConfiguredLengthAndAzimuth) {
+	simulation::Simulation sim;
+	sim.launcher_length  = 12.0;   // Astra: 12 m rail
+	sim.launcher_azimuth = 133.0;  // Astra: heading 133 deg
+	auto l = sim.make_launcher(84.0);
+	EXPECT_DOUBLE_EQ(l.length, 12.0);
+	EXPECT_NEAR(l.azimuth(),   133.0, TOL);
+	EXPECT_NEAR(l.elevation(),  84.0, TOL);
+}


### PR DESCRIPTION
## 概要

`main.cpp` がランチャを `Launcher(5.0, 150.0, e)` とハードコードしていたため、
`config.toml` の `[launcher] length` が**黙って無視**され、方位（azimuth）は
そもそも設定できなかった。実機に忠実な example（例: 12 m レール・方位 133° で
打ち上げる Astra）の打上げジオメトリを表現する手段が無かった。

## 変更内容

- `[launcher] length` を尊重し、`[launcher] azimuth` を新設。どちらも省略可で、
  省略時は従来のハードコード相当（5 m / 150°）になる**後方互換**デフォルト。
- 設定された length / azimuth と、掃引される elevation から `Launcher` を組み立てる
  処理を `Simulation::make_launcher(elevation)` に集約。`main.cpp` は毎 run これを呼ぶ。
- 未初期化で未使用だった `Simulation::launcher_angle` を、デフォルト初期化された
  上記 2 フィールドで置き換え。

```toml
[launcher]
length   = 12    # 省略時 5.0
elevation = 84
azimuth  = 133   # 省略時 150.0
```

## TDD

`test/test_launcher_config.cpp`（red → green）:

- `DefaultsMatchLegacyHardcode`: 未指定時に従来の 5 m / 150° になる
- `HonorsConfiguredLengthAndAzimuth`: 設定した length / azimuth が
  構築される `Launcher` に反映され、elevation は run ごとに渡る

全 12 テストスイート green、`trochia` 本体のビルドも確認。起動ログでも
`launcher: length=12, azimuth=133, elevation=84` を確認済み。

## 影響範囲

既存 config は `length`/`azimuth` 未指定なら従来と同一挙動（`length=5` を
明示していた PSAS example も挙動不変）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)