### PR TITLE
USSA1976 layered atmosphere (finite to high altitude, no NaN)

### DIFF
--- a/src/environment/air.hpp
+++ b/src/environment/air.hpp
@@ -22,26 +22,90 @@
 #ifndef ENVIRONMENT_AIR_HPP_
 #define ENVIRONMENT_AIR_HPP_
 
+#include <array>
+#include <utility>
 #include "../math.hpp"
 #include "temperature.hpp"
 
+// U.S. Standard Atmosphere, 1976 (USSA1976): https://ntrs.nasa.gov/citations/19770009539
+//
+// All inputs are *geopotential* height H [m] (convert geometric Z with
+// earth::geodesy::potential_height first). The 7 base layers reach H = 84852 m
+// (~86 km geometric); above that we extrapolate isothermally so density keeps
+// falling smoothly toward zero (never NaN), which is enough for a high-altitude
+// ballistic / hazard-zone estimate even though the real thermosphere is richer.
+//
+// At and below 11 km this matches the previous troposphere model to ~1e-5
+// (same lapse and P0; the old rho = 0.0034837*P/T is P/(R*T) with R ~= 287.05,
+// differing from R = 287.0528 only at the 5th digit), so existing low-altitude
+// results are unchanged to the precision anyone reads them at.
 namespace trochia::environment::air {
-	// from FROGS (return kelvin)
-	auto temperature(const math::Float &height) -> temperature::kelvin {
-		const auto height_km = height * 0.001;
-		return temperature::celsius(15.0 - 6.5*height_km);
+	namespace ussa1976 {
+		constexpr math::Float g0 = 9.80665;        // standard gravity [m/s^2]
+		constexpr math::Float R  = 287.0528;       // specific gas const = R*/M0 = 8.31432/0.0289644
+		constexpr math::Float P0 = 101325.0;       // sea-level pressure [Pa]
+		constexpr math::Float T0 = 288.15;         // sea-level temperature [K]
+		constexpr math::Float H_top = 84852.0;     // top of the tabulated layers [m]
+
+		// {base geopotential height [m], lapse rate [K/km]} for layers 0..6.
+		// Base temperatures follow by continuity from T0 (216.65, 216.65, 228.65,
+		// 270.65, 270.65, 214.65), and T at H_top works out to 186.946 K.
+		inline auto layers() -> const std::array<std::pair<math::Float, math::Float>, 7> & {
+			static const std::array<std::pair<math::Float, math::Float>, 7> table = {{
+				{     0.0, -6.5 },
+				{ 11000.0,  0.0 },
+				{ 20000.0,  1.0 },
+				{ 32000.0,  2.8 },
+				{ 47000.0,  0.0 },
+				{ 51000.0, -2.8 },
+				{ 71000.0, -2.0 },
+			}};
+			return table;
+		}
+
+		// temperature [K] and pressure [Pa] at geopotential height H [m].
+		inline auto props(math::Float H) -> std::pair<math::Float, math::Float> {
+			if(H < 0.0) H = 0.0;	// clamp below sea level
+			const auto &layer = layers();
+			math::Float Hb = layer[0].first, Tb = T0, Pb = P0;
+			for(std::size_t i = 0; i < layer.size(); ++i){
+				const math::Float L  = layer[i].second / 1000.0;	// K/km -> K/m
+				const math::Float Ht = (i + 1 < layer.size()) ? layer[i + 1].first : H_top;
+				if(H <= Ht){
+					const math::Float T = Tb + L * (H - Hb);
+					const math::Float P = (L == 0.0)
+						? Pb * std::exp(-g0 * (H - Hb) / (R * Tb))
+						: Pb * std::pow(T / Tb, -g0 / (R * L));
+					return { T, P };
+				}
+				// advance the running base (T, P) to the top of this layer
+				const math::Float Tt = Tb + L * (Ht - Hb);
+				Pb = (L == 0.0)
+					? Pb * std::exp(-g0 * (Ht - Hb) / (R * Tb))
+					: Pb * std::pow(Tt / Tb, -g0 / (R * L));
+				Tb = Tt;
+				Hb = Ht;
+			}
+			// above H_top: isothermal extrapolation (Tb = 186.946 K, Pb = P(H_top))
+			const math::Float P = Pb * std::exp(-g0 * (H - Hb) / (R * Tb));
+			return { Tb, P };
+		}
 	}
 
-	// from FROGS (return Pa)
-	auto pressure(const temperature::kelvin &t) -> math::Float {
-		const math::Float t_ = t;
-		return 101325.0 * std::pow((288.15 / t_), -5.256);
+	// temperature [K] at geopotential height H [m]
+	inline auto temperature(const math::Float &H) -> temperature::kelvin {
+		return temperature::kelvin(ussa1976::props(H).first);
 	}
 
-	// from FROGS (Don't use this equation over 11km)
-	auto density(const temperature::kelvin &t) -> math::Float {
-		const math::Float t_ = t;
-		return (0.0034837 * pressure(t)) / t_;
+	// pressure [Pa] at geopotential height H [m]
+	inline auto pressure(const math::Float &H) -> math::Float {
+		return ussa1976::props(H).second;
+	}
+
+	// density [kg/m^3] at geopotential height H [m]
+	inline auto density(const math::Float &H) -> math::Float {
+		const auto [T, P] = ussa1976::props(H);
+		return P / (ussa1976::R * T);
 	}
 }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -185,7 +185,7 @@ auto trochia::simulation::do_step(Simulation &sim, solver::solver<rocket::Rocket
 	const auto altitude = rocket.pos.altitude();
 	sim.geo_height = environment::earth::geodesy::potential_height(altitude);
 	sim.temperature = environment::air::temperature(sim.geo_height);
-	sim.rho = environment::air::density(sim.temperature);
+	sim.rho = environment::air::density(sim.geo_height);
 
 	// recovery (issue #6): detect apogee (the climb turning to descent, NED down
 	// velocity going positive after launch clear) and deploy the parachute after

--- a/test/test_air.cpp
+++ b/test/test_air.cpp
@@ -1,0 +1,110 @@
+// U.S. Standard Atmosphere 1976: temperature / pressure / density as a function
+// of geopotential height. Pinned against the published USSA1976 table at every
+// layer base, plus the properties that the old troposphere-only model lacked:
+// no NaN above ~44 km, and a finite, monotonically decreasing density all the
+// way up past where a sounding rocket flies.
+#include <gtest/gtest.h>
+#include <cmath>
+#include "environment/air.hpp"
+
+using namespace trochia;
+using environment::air::temperature;
+using environment::air::pressure;
+using environment::air::density;
+
+namespace {
+	// geopotential height [m], T [K], P [Pa], rho [kg/m^3] (USSA1976 table)
+	struct Ref { double H, T, P, rho; };
+	const Ref TABLE[] = {
+		{     0.0, 288.150, 101325.0,   1.225000   },
+		{ 11000.0, 216.650,  22632.0,   0.3639180  },
+		{ 20000.0, 216.650,   5474.88,  0.08803491 },
+		{ 32000.0, 228.650,    868.018, 0.01322500 },
+		{ 47000.0, 270.650,    110.906, 0.001427534},
+		{ 51000.0, 270.650,     66.9388,0.0008616040},
+		{ 71000.0, 214.650,      3.95642,6.421105e-5},
+		{ 84852.0, 186.946,      0.37338,6.957876e-6},
+	};
+}
+
+TEST(USSA1976, MatchesPublishedTableAtLayerBases) {
+	for (const auto &r : TABLE) {
+		EXPECT_NEAR(temperature(r.H), r.T, 0.05) << "T at H=" << r.H;
+		EXPECT_NEAR(pressure(r.H), r.P, r.P * 0.001) << "P at H=" << r.H;
+		EXPECT_NEAR(density(r.H),  r.rho, r.rho * 0.001) << "rho at H=" << r.H;
+	}
+}
+
+// The layered model must be continuous across every layer boundary: pressure
+// and temperature just below a base must match just above it (the base-chaining
+// would show a step here if a layer's formula or base value were wrong).
+TEST(USSA1976, ContinuousAcrossLayerBoundaries) {
+	const double BASES[] = {11000, 20000, 32000, 47000, 51000, 71000, 84852};
+	for (double Hb : BASES) {
+		const double below_P = pressure(Hb - 0.01), above_P = pressure(Hb + 0.01);
+		const double below_T = temperature(Hb - 0.01), above_T = temperature(Hb + 0.01);
+		EXPECT_NEAR(below_P, above_P, above_P * 1e-5) << "P jump at H=" << Hb;
+		EXPECT_NEAR(below_T, above_T, 1e-3)           << "T jump at H=" << Hb;
+	}
+}
+
+// Mid-layer points exercise the per-layer barometric formula, not just the
+// base-to-base continuity. Reference values come from an INDEPENDENT USSA1976
+// implementation (Python `ambiance`), evaluated at these exact geopotential
+// heights -- so this cross-checks the formula against a second source, not just
+// our own table. (Cross-checked across 0-80 km to < 0.001 % relative.)
+TEST(USSA1976, MatchesIndependentImplMidLayer) {
+	const Ref MID[] = {
+		{  5000.0, 255.650, 54019.9,    0.736116    },  // layer 0 (troposphere)
+		{ 25000.0, 221.650,  2511.01,   0.0394657   },  // layer 2 (+1.0 K/km)
+		{ 40000.0, 251.050,   277.52,   0.00385099  },  // layer 3 (+2.8 K/km)
+		{ 60000.0, 245.450,    20.3141, 0.000288319 },  // layer 5 (-2.8 K/km)
+		{ 70000.0, 217.450,     4.63418,7.42423e-5  },  // layer 6 (-2.0 K/km)
+	};
+	for (const auto &r : MID) {
+		EXPECT_NEAR(temperature(r.H), r.T, 0.05) << "T at H=" << r.H;
+		EXPECT_NEAR(pressure(r.H), r.P, r.P * 0.001) << "P at H=" << r.H;
+		EXPECT_NEAR(density(r.H),  r.rho, r.rho * 0.001) << "rho at H=" << r.H;
+	}
+}
+
+// The old model went NaN above ~44 km (T <= 0 K -> pow of a negative base).
+// Every altitude a sounding rocket reaches must give a finite, positive density.
+TEST(USSA1976, FiniteEverywhereNoNaN) {
+	for (double H = 0.0; H <= 120000.0; H += 1000.0) {
+		const double rho = density(H);
+		const double p   = pressure(H);
+		const double T   = temperature(H);
+		EXPECT_TRUE(std::isfinite(rho) && rho > 0.0) << "rho at H=" << H;
+		EXPECT_TRUE(std::isfinite(p) && p > 0.0)     << "P at H=" << H;
+		EXPECT_TRUE(std::isfinite(T) && T > 0.0)     << "T at H=" << H;
+	}
+}
+
+// Density must decrease monotonically with height (the troposphere model did
+// not, near the layer where T crossed zero).
+TEST(USSA1976, DensityMonotonicDecrease) {
+	double prev = density(0.0);
+	for (double H = 1000.0; H <= 120000.0; H += 1000.0) {
+		const double rho = density(H);
+		EXPECT_LT(rho, prev) << "rho not decreasing at H=" << H;
+		prev = rho;
+	}
+}
+
+// Above the 86 km (H=84852 m) table top we extrapolate isothermally; density
+// keeps falling smoothly toward zero, well past MOMO's ~113 km apogee.
+TEST(USSA1976, AboveTableTopExtrapolatesSmall) {
+	const double top = density(84852.0);
+	const double high = density(111000.0);   // ~113 km geometric
+	EXPECT_GT(high, 0.0);
+	EXPECT_LT(high, top);
+	EXPECT_LT(high, 1e-4);                    // genuinely thin air up there
+	EXPECT_DOUBLE_EQ(temperature(111000.0), temperature(90000.0)); // isothermal
+}
+
+// Below sea level is clamped to sea-level conditions (no negative-height blowup).
+TEST(USSA1976, BelowSeaLevelClamped) {
+	EXPECT_NEAR(density(-100.0), density(0.0), 1e-12);
+	EXPECT_NEAR(temperature(-100.0), 288.150, 1e-9);
+}


### PR DESCRIPTION
## 概要

大気モデルが**対流圏のみの ISA 近似**だった: `temperature(H)=15-6.5·H_km [℃]`、
かつ `pressure`/`density` は**温度を引数**に取りこの線形ラプスを逆算する設計。
~11 km 超で不正確、~44 km 超では温度が ≤0 K になり
`pressure=pow(288.15/T,-5.256)`・`density` が **NaN** になる（=高高度＝観測ロケット
等のシミュレーションが黙って破綻する）。

## 可視化: 旧モデル vs USSA1976（本 PR）

![atmosphere](https://raw.githubusercontent.com/sksat/trochia/eeee0433c1974f39bf8d53e18f0a1ff387cc6cba/atmosphere.png)

- **左（温度）**: 旧モデル（赤破線）は線形に下がり ~44 km で 0 K を割って負へ →
  `pow(負)` で NaN。新 USSA1976（青）は現実的な層構造。
- **右（密度, log）**: 新モデル（青）は 113 km まで滑らかに減衰。独立実装
  **`ambiance`（橙○）と完全に重なる**＝検証 OK。旧モデル（赤破線）は ~20 km から
  乖離し ~44 km 超で NaN。

## 変更内容

**U.S. Standard Atmosphere 1976** を**ジオポテンシャル高度 H** の関数として実装:

- 7 層（H=84852 m ≒ 幾何高度 86 km まで）。標準の base 高度／ラプス率、base 気圧は
  `P0=101325, T0=288.15, R=287.0528, g0=9.80665` から**連続性で連鎖計算**。
  ラプス層 `P=Pb·(T/Tb)^(-g0/(R·L))`、等温層 `P=Pb·exp(-g0·ΔH/(R·Tb))`。
- テーブル上端より上は**等温外挿**（T=186.946 K, 真の熱圏ではない有限外挿）→ 密度は
  0 へ滑らかに減衰し **NaN にならない**（その高度の密度は無視できるほど小さい）。
- `H<0` は海面にクランプ。

API を「温度引数」→「ジオポテンシャル高度引数」へ変更（`temperature(H)`,
`pressure(H)`, `density(H)`）。唯一の呼び出し元 `simulation.cpp` は既に
ジオポテンシャル高度を計算済みなので、それを `density()` に渡すだけ。

## 妥当性検証（TDD: test_air, red→green）

| 検証 | 内容 | 結果 |
|---|---|---|
| 公表テーブル | 各層 base（0〜84.852 km）の T/P/rho | 0.1% 以内で一致 |
| **独立実装クロス検証** | Python `ambiance`（USSA1976）と層途中点で比較 | **0–80 km で <0.001% 一致** |
| 境界連続性 | 各層境界の上下で P/T が連続 | 段差なし |
| NaN なし | 0〜120 km で有限・正値 | OK（旧モデルは ~44 km 超で NaN） |
| 単調性 | 密度が高度に対し単調減少 | OK |
| 外挿 | MOMO の ~113 km 超まで滑らかに微小 | OK |

全 14 テストスイート green、`trochia` 本体ビルド確認。

## 後方互換

≤11 km では旧モデルと ~1e-5 で一致（ラプス・P0 同一、旧 `rho=0.0034837·P/T` は
`R≈287.05` の `P/(R·T)`、本実装 287.0528 とは 5 桁目のみ差）。既存 example は
読み取り精度の範囲で不変 — **Astra example の apogee は前後とも 3260.1 m**（回帰なし）。

## 今後

これで高高度モデル（例: 観測ロケット MOMO ~113 km）の前提（NaN にならない大気）が整う。
Mach 依存 Cd・音速 `a=sqrt(γRT)` の追加は必要に応じて別 PR で（YAGNI）。

> 図は未マージの `assets/atmosphere-viz` ブランチに置き、SHA 固定の raw URL で参照（master を汚さない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)